### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
 
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -85,6 +87,8 @@ jobs:
 
   build:
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Potential fix for [https://github.com/khaphanspace/gonhanh.org/security/code-scanning/2](https://github.com/khaphanspace/gonhanh.org/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to each job that currently lacks one, specifying only the minimal required permissions. For CI jobs that only check out code, build, run formatters, and run unit tests—such as "check" and "build" here—`contents: read` is sufficient, as these jobs do not need to write to the repo or perform privileged operations. Specifically:
- Add a `permissions:` section to the "check" and "build" jobs.
- Place `permissions:` directly under the job name, with `contents: read` indented beneath.
- No change to "analyze," as appropriate permissions already exist.
No extra imports, definitions, or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
