### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
 
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Potential fix for [https://github.com/khaphanspace/gonhanh.org/security/code-scanning/1](https://github.com/khaphanspace/gonhanh.org/security/code-scanning/1)

To fix this problem, add a minimal `permissions` block to the `check` job to reduce the GITHUB_TOKEN privileges to only what is necessary. For this particular job, the only operation it does which requires token permissions is the code checkout step; this can be performed with `contents: read`. Insert a `permissions:` line with `contents: read` directly under the existing `runs-on: ubuntu-latest` for the `check` job in `.github/workflows/ci.yml` (i.e., after line 73 and before `steps:` on line 74) and ensure indentation matches the surrounding YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
