### PR TITLE
perf(macos): use LazyVStack for shortcut table virtualization

### DIFF
--- a/platforms/macos/MainSettingsView.swift
+++ b/platforms/macos/MainSettingsView.swift
@@ -19,21 +19,10 @@ enum NavigationPage: String, CaseIterable {
 // MARK: - Update Status
 
 enum UpdateStatus: Equatable {
-    case idle
-    case checking
-    case upToDate
-    case available(String)  // New version string
-    case error
+    case idle, checking, upToDate, available(String), error
 
-    var isChecking: Bool {
-        if case .checking = self { return true }
-        return false
-    }
-
-    var isAvailable: Bool {
-        if case .available = self { return true }
-        return false
-    }
+    var isChecking: Bool { if case .checking = self { return true }; return false }
+    var isAvailable: Bool { if case .available = self { return true }; return false }
 }
 
 // MARK: - App State
@@ -41,21 +30,16 @@ enum UpdateStatus: Equatable {
 class AppState: ObservableObject {
     static let shared = AppState()
 
-    // Flag for silent updates (from app switch) - won't trigger save
     private var isSilentUpdate = false
+    private var cancellables = Set<AnyCancellable>()
+    private var launchAtLoginTimer: Timer?
 
     @Published var isEnabled: Bool {
         didSet {
-            // Always sync engine and update icon
             RustBridge.setEnabled(isEnabled)
             NotificationCenter.default.post(name: .menuStateChanged, object: nil)
-
-            // Skip save when silent update (from app switch restore)
             guard !isSilentUpdate else { return }
-
             UserDefaults.standard.set(isEnabled, forKey: SettingsKey.enabled)
-
-            // Save for current app if smart mode enabled
             if isSmartModeEnabled,
                let bundleId = NSWorkspace.shared.frontmostApplication?.bundleIdentifier {
                 savePerAppMode(bundleId: bundleId, enabled: isEnabled)
@@ -71,29 +55,15 @@ class AppState: ObservableObject {
         }
     }
 
-    /// Smart mode: automatically remember ON/OFF state per app
     @Published var isSmartModeEnabled: Bool = true {
-        didSet {
-            UserDefaults.standard.set(isSmartModeEnabled, forKey: SettingsKey.smartModeEnabled)
-        }
+        didSet { UserDefaults.standard.set(isSmartModeEnabled, forKey: SettingsKey.smartModeEnabled) }
     }
 
-    /// Auto W→Ư shortcut: when enabled, 'w' at word start converts to 'ư' (Telex only)
     @Published var autoWShortcut: Bool = true {
         didSet {
             UserDefaults.standard.set(autoWShortcut, forKey: SettingsKey.autoWShortcut)
-            RustBridge.setSkipWShortcut(!autoWShortcut)  // Invert: skip = !auto
+            RustBridge.setSkipWShortcut(!autoWShortcut)
         }
-    }
-
-    /// Toggle Vietnamese input on/off
-    func toggle() {
-        isEnabled.toggle()
-    }
-
-    /// Set input method (Telex/VNI)
-    func setMethod(_ method: InputMode) {
-        currentMethod = method
     }
 
     @Published var toggleShortcut: KeyboardShortcut {
@@ -104,43 +74,48 @@ class AppState: ObservableObject {
     }
 
     @Published var updateStatus: UpdateStatus = .idle
-
     @Published var shortcuts: [ShortcutItem] = []
-
-    /// Launch at Login status (auto-refreshed)
     @Published var isLaunchAtLoginEnabled: Bool = false
 
-    /// Timer for refreshing launch at login status
-    private var launchAtLoginTimer: Timer?
+    // MARK: - Init
 
     init() {
         isEnabled = UserDefaults.standard.object(forKey: SettingsKey.enabled) as? Bool ?? true
         currentMethod = InputMode(rawValue: UserDefaults.standard.integer(forKey: SettingsKey.method)) ?? .telex
         toggleShortcut = KeyboardShortcut.load()
 
-        // Smart mode (default true for new installs)
+        loadSmartMode()
+        loadAutoWShortcut()
+        loadShortcuts()
+        setupObservers()
+        setupLaunchAtLoginMonitoring()
+        checkForUpdates()
+    }
+
+    private func loadSmartMode() {
         if UserDefaults.standard.object(forKey: SettingsKey.smartModeEnabled) == nil {
             isSmartModeEnabled = true
             UserDefaults.standard.set(true, forKey: SettingsKey.smartModeEnabled)
         } else {
             isSmartModeEnabled = UserDefaults.standard.bool(forKey: SettingsKey.smartModeEnabled)
         }
+    }
 
-        // Auto W→Ư shortcut (default true for new installs)
+    private func loadAutoWShortcut() {
         if UserDefaults.standard.object(forKey: SettingsKey.autoWShortcut) == nil {
             autoWShortcut = true
             UserDefaults.standard.set(true, forKey: SettingsKey.autoWShortcut)
         } else {
             autoWShortcut = UserDefaults.standard.bool(forKey: SettingsKey.autoWShortcut)
         }
-        RustBridge.setSkipWShortcut(!autoWShortcut)  // Invert: skip = !auto
+        RustBridge.setSkipWShortcut(!autoWShortcut)
+    }
 
-        // Load shortcuts from UserDefaults (or use defaults)
+    private func loadShortcuts() {
         if let data = UserDefaults.standard.data(forKey: SettingsKey.shortcuts),
            let saved = try? JSONDecoder().decode([ShortcutItem].self, from: data) {
             shortcuts = saved
         } else {
-            // Default shortcuts (OFF by default)
             shortcuts = [
                 ShortcutItem(key: "vn", value: "Việt Nam", isEnabled: false),
                 ShortcutItem(key: "hn", value: "Hà Nội", isEnabled: false),
@@ -148,90 +123,17 @@ class AppState: ObservableObject {
                 ShortcutItem(key: "tphcm", value: "Thành phố Hồ Chí Minh", isEnabled: false),
             ]
         }
-
-        checkForUpdates()
-        setupObservers()
-        setupLaunchAtLoginMonitoring()
     }
 
-    // MARK: - Launch at Login Monitoring
-
-    /// Start monitoring launch at login status
-    private func setupLaunchAtLoginMonitoring() {
-        // Initial check
-        isLaunchAtLoginEnabled = LaunchAtLoginManager.shared.isEnabled
-
-        // Refresh every 2 seconds (user may toggle in System Settings)
-        launchAtLoginTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
-            DispatchQueue.main.async {
-                self?.refreshLaunchAtLoginStatus()
-            }
-        }
-    }
-
-    /// Refresh launch at login status from system
-    func refreshLaunchAtLoginStatus() {
-        let newStatus = LaunchAtLoginManager.shared.isEnabled
-        if newStatus != isLaunchAtLoginEnabled {
-            isLaunchAtLoginEnabled = newStatus
-        }
-    }
-
-    /// Enable launch at login (register with SMAppService)
-    func enableLaunchAtLogin() {
-        do {
-            try LaunchAtLoginManager.shared.enable()
-            refreshLaunchAtLoginStatus()
-        } catch {
-            // If registration fails or requires approval, open System Settings
-            openLoginItemsSettings()
-        }
-    }
-
-    /// Open macOS Login Items settings
-    func openLoginItemsSettings() {
-        // macOS 13+ Login Items URL
-        if let url = URL(string: "x-apple.systempreferences:com.apple.LoginItems-Settings.extension") {
-            NSWorkspace.shared.open(url)
-        }
-    }
-
-    // MARK: - Per-App Mode (only stores OFF apps, default is ON)
-
-    /// Save per-app mode: only store OFF apps, remove entry when ON (default)
-    func savePerAppMode(bundleId: String, enabled: Bool) {
-        var modes = UserDefaults.standard.dictionary(forKey: SettingsKey.perAppModes) as? [String: Bool] ?? [:]
-        if enabled {
-            modes.removeValue(forKey: bundleId)  // ON is default, no need to store
-        } else {
-            modes[bundleId] = false  // Only store OFF apps
-        }
-        UserDefaults.standard.set(modes, forKey: SettingsKey.perAppModes)
-    }
-
-    /// Get per-app mode: returns true (ON) if not stored
-    func getPerAppMode(bundleId: String) -> Bool {
-        let modes = UserDefaults.standard.dictionary(forKey: SettingsKey.perAppModes) as? [String: Bool] ?? [:]
-        return modes[bundleId] ?? true  // Default ON
-    }
-
-    /// Silent update (from app switch) - won't trigger save, but still updates UI via Combine
-    func setEnabledSilently(_ enabled: Bool) {
-        isSilentUpdate = true
-        isEnabled = enabled
-        isSilentUpdate = false
-    }
+    // MARK: - Observers
 
     private func setupObservers() {
-        // Observe changes to sync to engine and save to UserDefaults
         $shortcuts
-            .dropFirst() // Skip initial value
+            .dropFirst()
             .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
             .sink { [weak self] shortcuts in
-                // Only sync valid shortcuts (both key and value non-empty)
                 let validShortcuts = shortcuts.filter { !$0.key.isEmpty && !$0.value.isEmpty }
                 self?.syncShortcutsToEngine(validShortcuts)
-                // Save all to UserDefaults (including empty for editing)
                 if let data = try? JSONEncoder().encode(shortcuts) {
                     UserDefaults.standard.set(data, forKey: SettingsKey.shortcuts)
                 }
@@ -239,18 +141,64 @@ class AppState: ObservableObject {
             .store(in: &cancellables)
     }
 
-    private var cancellables = Set<AnyCancellable>()
+    // MARK: - Launch at Login
 
-    /// Sync shortcuts to Rust engine (only valid ones with non-empty key/value)
-    func syncShortcutsToEngine(_ validShortcuts: [ShortcutItem]? = nil) {
-        let toSync = validShortcuts ?? shortcuts.filter { !$0.key.isEmpty && !$0.value.isEmpty }
-        let data = toSync.map { ($0.key, $0.value, $0.isEnabled) }
-        RustBridge.syncShortcuts(data)
+    private func setupLaunchAtLoginMonitoring() {
+        isLaunchAtLoginEnabled = LaunchAtLoginManager.shared.isEnabled
+        launchAtLoginTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
+            DispatchQueue.main.async { self?.refreshLaunchAtLoginStatus() }
+        }
     }
 
-    // MARK: - Import/Export Shortcuts (OpenKey format)
+    func refreshLaunchAtLoginStatus() {
+        let newStatus = LaunchAtLoginManager.shared.isEnabled
+        if newStatus != isLaunchAtLoginEnabled { isLaunchAtLoginEnabled = newStatus }
+    }
 
-    /// Export shortcuts to text format (compatible with OpenKey/UniKey)
+    func enableLaunchAtLogin() {
+        do {
+            try LaunchAtLoginManager.shared.enable()
+            refreshLaunchAtLoginStatus()
+        } catch {
+            openLoginItemsSettings()
+        }
+    }
+
+    func openLoginItemsSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.LoginItems-Settings.extension") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    // MARK: - Per-App Mode
+
+    func savePerAppMode(bundleId: String, enabled: Bool) {
+        var modes = UserDefaults.standard.dictionary(forKey: SettingsKey.perAppModes) as? [String: Bool] ?? [:]
+        if enabled { modes.removeValue(forKey: bundleId) } else { modes[bundleId] = false }
+        UserDefaults.standard.set(modes, forKey: SettingsKey.perAppModes)
+    }
+
+    func getPerAppMode(bundleId: String) -> Bool {
+        let modes = UserDefaults.standard.dictionary(forKey: SettingsKey.perAppModes) as? [String: Bool] ?? [:]
+        return modes[bundleId] ?? true
+    }
+
+    func setEnabledSilently(_ enabled: Bool) {
+        isSilentUpdate = true
+        isEnabled = enabled
+        isSilentUpdate = false
+    }
+
+    func toggle() { isEnabled.toggle() }
+    func setMethod(_ method: InputMode) { currentMethod = method }
+
+    // MARK: - Shortcuts
+
+    func syncShortcutsToEngine(_ validShortcuts: [ShortcutItem]? = nil) {
+        let toSync = validShortcuts ?? shortcuts.filter { !$0.key.isEmpty && !$0.value.isEmpty }
+        RustBridge.syncShortcuts(toSync.map { ($0.key, $0.value, $0.isEnabled) })
+    }
+
     func exportShortcuts() -> String {
         var lines = [";Gõ Nhanh - Bảng gõ tắt"]
         for shortcut in shortcuts where !shortcut.key.isEmpty {
@@ -259,57 +207,47 @@ class AppState: ObservableObject {
         return lines.joined(separator: "\n")
     }
 
-    /// Import shortcuts from OpenKey-compatible format (merges with existing)
     func importShortcuts(from content: String) -> Int {
         let lines = content.components(separatedBy: .newlines)
         var imported = 0
-
         for line in lines {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
-            // Skip empty lines and comments
-            guard !trimmed.isEmpty, !trimmed.hasPrefix(";") else { continue }
-
-            // Parse trigger:replacement
-            if let colonIndex = trimmed.firstIndex(of: ":") {
-                let trigger = String(trimmed[..<colonIndex]).trimmingCharacters(in: .whitespaces)
-                let replacement = String(trimmed[trimmed.index(after: colonIndex)...]).trimmingCharacters(in: .whitespaces)
-
-                guard !trigger.isEmpty else { continue }
-
-                // Check if trigger already exists
-                if let idx = shortcuts.firstIndex(where: { $0.key == trigger }) {
-                    shortcuts[idx].value = replacement
-                    shortcuts[idx].isEnabled = true
-                } else {
-                    shortcuts.append(ShortcutItem(key: trigger, value: replacement, isEnabled: true))
-                }
-                imported += 1
+            guard !trimmed.isEmpty, !trimmed.hasPrefix(";"),
+                  let colonIndex = trimmed.firstIndex(of: ":") else { continue }
+            let trigger = String(trimmed[..<colonIndex]).trimmingCharacters(in: .whitespaces)
+            let replacement = String(trimmed[trimmed.index(after: colonIndex)...]).trimmingCharacters(in: .whitespaces)
+            guard !trigger.isEmpty else { continue }
+            if let idx = shortcuts.firstIndex(where: { $0.key == trigger }) {
+                shortcuts[idx].value = replacement
+                shortcuts[idx].isEnabled = true
+            } else {
+                shortcuts.append(ShortcutItem(key: trigger, value: replacement, isEnabled: true))
             }
+            imported += 1
         }
         return imported
     }
+
+    // MARK: - Updates
 
     func checkForUpdates() {
         updateStatus = .checking
         let startTime = Date()
         UpdateChecker.shared.checkForUpdates { [weak self] result in
-            // Ensure minimum 1.5s loading time for better UX
             let elapsed = Date().timeIntervalSince(startTime)
             let delay = max(0, 1.5 - elapsed)
             DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
                 switch result {
-                case .available(let info):
-                    self?.updateStatus = .available(info.version)
-                case .upToDate:
-                    self?.updateStatus = .upToDate
-                case .error:
-                    self?.updateStatus = .error
+                case .available(let info): self?.updateStatus = .available(info.version)
+                case .upToDate: self?.updateStatus = .upToDate
+                case .error: self?.updateStatus = .error
                 }
             }
         }
     }
 }
 
+// MARK: - Models
 
 struct ShortcutItem: Identifiable, Codable {
     var id = UUID()
@@ -318,7 +256,69 @@ struct ShortcutItem: Identifiable, Codable {
     var isEnabled: Bool = true
 }
 
-// MARK: - Clickable TextField (full-width click area)
+// MARK: - View Modifiers
+
+struct CardBackground: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background(RoundedRectangle(cornerRadius: 10).fill(Color(NSColor.controlBackgroundColor).opacity(0.5)))
+            .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color(NSColor.separatorColor).opacity(0.5), lineWidth: 0.5))
+    }
+}
+
+extension View {
+    func cardBackground() -> some View { modifier(CardBackground()) }
+}
+
+// MARK: - Reusable Components
+
+struct SettingsRow<Content: View>: View {
+    let content: Content
+    init(@ViewBuilder content: () -> Content) { self.content = content() }
+    var body: some View {
+        HStack { content }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+    }
+}
+
+struct SettingsToggleRow: View {
+    let title: String
+    let subtitle: String?
+    @Binding var isOn: Bool
+
+    init(_ title: String, subtitle: String? = nil, isOn: Binding<Bool>) {
+        self.title = title
+        self.subtitle = subtitle
+        self._isOn = isOn
+    }
+
+    var body: some View {
+        SettingsRow {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title).font(.system(size: 13))
+                if let subtitle = subtitle {
+                    Text(subtitle).font(.system(size: 11)).foregroundColor(Color(NSColor.secondaryLabelColor))
+                }
+            }
+            Spacer()
+            Toggle("", isOn: $isOn).toggleStyle(.switch).labelsHidden()
+        }
+    }
+}
+
+struct KeyCap: View {
+    let text: String
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundColor(Color(NSColor.secondaryLabelColor))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(RoundedRectangle(cornerRadius: 4).fill(Color(NSColor.controlBackgroundColor).opacity(0.8)))
+            .overlay(RoundedRectangle(cornerRadius: 4).stroke(Color(NSColor.separatorColor).opacity(0.5), lineWidth: 0.5))
+    }
+}
 
 struct ClickableTextField: NSViewRepresentable {
     @Binding var text: String
@@ -335,26 +335,36 @@ struct ClickableTextField: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSTextField, context: Context) {
-        if nsView.stringValue != text {
-            nsView.stringValue = text
-        }
+        if nsView.stringValue != text { nsView.stringValue = text }
     }
 
-    func makeCoordinator() -> Coordinator {
-        Coordinator(self)
-    }
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
 
     class Coordinator: NSObject, NSTextFieldDelegate {
         var parent: ClickableTextField
-
-        init(_ parent: ClickableTextField) {
-            self.parent = parent
-        }
-
+        init(_ parent: ClickableTextField) { self.parent = parent }
         func controlTextDidChange(_ obj: Notification) {
             guard let textField = obj.object as? NSTextField else { return }
             parent.text = textField.stringValue
         }
+    }
+}
+
+struct VisualEffectBackground: NSViewRepresentable {
+    var material: NSVisualEffectView.Material = .sidebar
+    var blendingMode: NSVisualEffectView.BlendingMode = .behindWindow
+
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = material
+        view.blendingMode = blendingMode
+        view.state = .active
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
+        nsView.material = material
+        nsView.blendingMode = blendingMode
     }
 }
 
@@ -365,20 +375,16 @@ struct MainSettingsView: View {
     @State private var selectedPage: NavigationPage = .settings
     @Environment(\.colorScheme) private var colorScheme
 
-    private var isDark: Bool { colorScheme == .dark }
-
     var body: some View {
         HStack(spacing: 0) {
-            // Sidebar
             ZStack {
                 VisualEffectBackground(material: .sidebar, blendingMode: .behindWindow)
                 sidebar
             }
             .frame(width: 200)
 
-            // Content
             ZStack {
-                if isDark {
+                if colorScheme == .dark {
                     VisualEffectBackground(material: .headerView, blendingMode: .behindWindow)
                 } else {
                     Color(NSColor.windowBackgroundColor)
@@ -389,9 +395,7 @@ struct MainSettingsView: View {
         .ignoresSafeArea()
         .frame(width: 700, height: 480)
         .onReceive(NotificationCenter.default.publisher(for: .showSettingsPage)) { notification in
-            if let page = notification.object as? NavigationPage {
-                selectedPage = page
-            }
+            if let page = notification.object as? NavigationPage { selectedPage = page }
         }
     }
 
@@ -399,39 +403,22 @@ struct MainSettingsView: View {
 
     private var sidebar: some View {
         VStack(spacing: 0) {
-            // Logo
             VStack(spacing: 12) {
-                Image(nsImage: AppMetadata.logo)
-                    .resizable()
-                    .frame(width: 96, height: 96)
-
-                Text(AppMetadata.name)
-                    .font(.system(size: 20, weight: .bold))
-
-                // Version badge with update status
-                updateBadge
+                Image(nsImage: AppMetadata.logo).resizable().frame(width: 96, height: 96)
+                Text(AppMetadata.name).font(.system(size: 20, weight: .bold))
+                UpdateBadgeView(status: appState.updateStatus) { appState.checkForUpdates() }
             }
             .padding(.top, 40)
 
             Spacer()
 
-            // Navigation
             VStack(spacing: 4) {
                 ForEach(NavigationPage.allCases, id: \.self) { page in
-                    NavButton(page: page, isSelected: selectedPage == page) {
-                        selectedPage = page
-                    }
+                    NavButton(page: page, isSelected: selectedPage == page) { selectedPage = page }
                 }
             }
             .padding(.horizontal, 12)
             .padding(.bottom, 20)
-        }
-    }
-
-    @ViewBuilder
-    private var updateBadge: some View {
-        UpdateBadgeView(status: appState.updateStatus) {
-            appState.checkForUpdates()
         }
     }
 
@@ -442,14 +429,11 @@ struct MainSettingsView: View {
         switch selectedPage {
         case .settings:
             ScrollView(showsIndicators: false) {
-                SettingsPageView(appState: appState)
-                    .padding(28)
+                SettingsPageView(appState: appState).padding(28)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         case .about:
-            AboutPageView()
-                .padding(28)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            AboutPageView().padding(28).frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 }
@@ -459,7 +443,6 @@ struct MainSettingsView: View {
 struct UpdateBadgeView: View {
     let status: UpdateStatus
     let onCheck: () -> Void
-
     @State private var hovered = false
     @State private var rotation: Double = 0
 
@@ -475,66 +458,45 @@ struct UpdateBadgeView: View {
 
     private var statusIcon: (name: String, color: Color)? {
         switch status {
-        case .idle: return nil
-        case .checking: return nil  // Handled separately with animation
         case .upToDate: return ("checkmark.circle.fill", .green)
         case .available: return ("arrow.up.circle.fill", .orange)
         case .error: return ("exclamationmark.triangle.fill", .orange)
+        default: return nil
         }
     }
 
     var body: some View {
         HStack(spacing: 3) {
             Text("v\(AppMetadata.version)")
-
-            // Icon (all filled circle style)
             if status.isChecking {
                 Image(systemName: "arrow.clockwise.circle.fill")
                     .font(.system(size: 12))
                     .foregroundColor(.secondary)
                     .rotationEffect(.degrees(rotation))
-                    .onAppear {
-                        withAnimation(.linear(duration: 1).repeatForever(autoreverses: false)) {
-                            rotation = 360
-                        }
-                    }
+                    .onAppear { withAnimation(.linear(duration: 1).repeatForever(autoreverses: false)) { rotation = 360 } }
                     .onDisappear { rotation = 0 }
             } else if let icon = statusIcon {
-                Image(systemName: icon.name)
-                    .font(.system(size: 12))
-                    .foregroundColor(icon.color)
+                Image(systemName: icon.name).font(.system(size: 12)).foregroundColor(icon.color)
             }
-
-            // Text
-            if let text = statusText {
-                Text(text)
-            }
+            if let text = statusText { Text(text) }
         }
         .font(.system(size: 11))
         .foregroundColor(Color(NSColor.tertiaryLabelColor))
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
-        .background(
-            Capsule()
-                .fill(hovered ? Color(NSColor.controlBackgroundColor).opacity(0.5) : Color.clear)
-        )
+        .background(Capsule().fill(hovered ? Color(NSColor.controlBackgroundColor).opacity(0.5) : Color.clear))
         .onHover { h in
             hovered = h
-            if status.isAvailable {
-                if h { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-            }
+            if status.isAvailable { if h { NSCursor.pointingHand.push() } else { NSCursor.pop() } }
         }
         .onTapGesture {
             guard !status.isChecking else { return }
             if status.isAvailable {
-                // Show update window AND start download immediately
                 if case .available(let info) = UpdateManager.shared.state {
                     UpdateManager.shared.downloadUpdate(info)
                     NotificationCenter.default.post(name: .showUpdateWindow, object: nil)
                 }
-            } else {
-                onCheck()
-            }
+            } else { onCheck() }
         }
     }
 }
@@ -545,7 +507,6 @@ struct NavButton: View {
     let page: NavigationPage
     let isSelected: Bool
     let action: () -> Void
-
     @State private var hovered = false
 
     var body: some View {
@@ -581,142 +542,77 @@ struct SettingsPageView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
-            // Launch at Login warning banner
+            // Launch at Login warning
             if !appState.isLaunchAtLoginEnabled {
-                LaunchAtLoginBanner {
-                    appState.enableLaunchAtLogin()
-                }
+                LaunchAtLoginBanner { appState.enableLaunchAtLogin() }
             }
 
             // General settings
             VStack(spacing: 0) {
-                // Enable toggle
-                HStack {
-                    Text("Bộ gõ tiếng Việt")
-                        .font(.system(size: 13))
-                    Spacer()
-                    Toggle("", isOn: $appState.isEnabled)
-                        .toggleStyle(.switch)
-                        .labelsHidden()
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-
+                SettingsToggleRow("Bộ gõ tiếng Việt", isOn: $appState.isEnabled)
                 Divider().padding(.leading, 12)
-
-                // Input method
-                HStack {
-                    Text("Kiểu gõ")
-                        .font(.system(size: 13))
-                    Spacer()
-                    Picker("", selection: $appState.currentMethod) {
-                        ForEach(InputMode.allCases, id: \.self) { mode in
-                            Text(mode.name).tag(mode)
-                        }
-                    }
-                    .labelsHidden()
-                    .frame(width: 100)
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-
+                inputMethodRow
                 Divider().padding(.leading, 12)
-
-                // Shortcut (clickable)
-                ShortcutRecorderRow(
-                    shortcut: $appState.toggleShortcut,
-                    isRecording: $isRecordingShortcut
-                )
+                ShortcutRecorderRow(shortcut: $appState.toggleShortcut, isRecording: $isRecordingShortcut)
             }
-            .background(
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(Color(NSColor.controlBackgroundColor).opacity(0.5))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(Color(NSColor.separatorColor).opacity(0.5), lineWidth: 0.5)
-            )
+            .cardBackground()
 
             // Options section
             VStack(spacing: 0) {
-                // Smart Mode
-                HStack {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Chuyển chế độ thông minh")
-                            .font(.system(size: 13))
-                        Text("Tự động nhớ trạng thái Anh/Việt cho từng ứng dụng")
-                            .font(.system(size: 11))
-                            .foregroundColor(Color(NSColor.secondaryLabelColor))
-                    }
-                    Spacer()
-                    Toggle("", isOn: $appState.isSmartModeEnabled)
-                        .toggleStyle(.switch)
-                        .labelsHidden()
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
+                SettingsToggleRow("Chuyển chế độ thông minh",
+                                  subtitle: "Tự động nhớ trạng thái Anh/Việt cho từng ứng dụng",
+                                  isOn: $appState.isSmartModeEnabled)
 
-                // Auto W→Ư shortcut (Telex only)
                 if appState.currentMethod == .telex {
                     Divider().padding(.leading, 12)
-
-                    HStack {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Tự chuyển W → Ư ở đầu từ")
-                                .font(.system(size: 13))
-                            Text("Gõ 'w' đầu từ sẽ thành 'ư'")
-                                .font(.system(size: 11))
-                                .foregroundColor(Color(NSColor.secondaryLabelColor))
-                        }
-                        Spacer()
-                        Toggle("", isOn: $appState.autoWShortcut)
-                            .toggleStyle(.switch)
-                            .labelsHidden()
-                    }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 10)
+                    SettingsToggleRow("Tự chuyển W → Ư ở đầu từ",
+                                      subtitle: "Gõ 'w' đầu từ sẽ thành 'ư'",
+                                      isOn: $appState.autoWShortcut)
                 }
 
                 Divider().padding(.leading, 12)
-
-                // Shortcuts - opens sheet
-                Button(action: { showShortcutsSheet = true }) {
-                    HStack {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Từ viết tắt")
-                                .font(.system(size: 13))
-                                .foregroundColor(Color(NSColor.labelColor))
-                            Text(appState.shortcuts.isEmpty
-                                ? "Chưa có từ viết tắt"
-                                : "\(appState.shortcuts.filter(\.isEnabled).count)/\(appState.shortcuts.count) đang bật")
-                                .font(.system(size: 11))
-                                .foregroundColor(Color(NSColor.secondaryLabelColor))
-                        }
-                        Spacer()
-                        Image(systemName: "chevron.right")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundColor(Color(NSColor.tertiaryLabelColor))
-                    }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 10)
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
+                shortcutsRow
             }
-            .background(
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(Color(NSColor.controlBackgroundColor).opacity(0.5))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(Color(NSColor.separatorColor).opacity(0.5), lineWidth: 0.5)
-            )
+            .cardBackground()
 
             Spacer()
         }
-        .sheet(isPresented: $showShortcutsSheet) {
-            ShortcutsSheet(appState: appState)
+        .sheet(isPresented: $showShortcutsSheet) { ShortcutsSheet(appState: appState) }
+    }
+
+    private var inputMethodRow: some View {
+        SettingsRow {
+            Text("Kiểu gõ").font(.system(size: 13))
+            Spacer()
+            Picker("", selection: $appState.currentMethod) {
+                ForEach(InputMode.allCases, id: \.self) { Text($0.name).tag($0) }
+            }
+            .labelsHidden()
+            .frame(width: 100)
         }
+    }
+
+    private var shortcutsRow: some View {
+        Button(action: { showShortcutsSheet = true }) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Từ viết tắt").font(.system(size: 13)).foregroundColor(Color(NSColor.labelColor))
+                    Text(appState.shortcuts.isEmpty
+                         ? "Chưa có từ viết tắt"
+                         : "\(appState.shortcuts.filter(\.isEnabled).count)/\(appState.shortcuts.count) đang bật")
+                        .font(.system(size: 11))
+                        .foregroundColor(Color(NSColor.secondaryLabelColor))
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(Color(NSColor.tertiaryLabelColor))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 }
 
@@ -729,107 +625,63 @@ struct ShortcutsSheet: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Header
-            HStack {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Từ viết tắt")
-                        .font(.system(size: 15, weight: .semibold))
-                    Text("\(appState.shortcuts.count) mục")
-                        .font(.system(size: 11))
-                        .foregroundColor(.secondary)
-                }
-                Spacer()
-                Button("Xong") { dismiss() }
-                    .keyboardShortcut(.return, modifiers: [])
-            }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 16)
-
+            header
             Divider()
-
-            // Table
-            if appState.shortcuts.isEmpty {
-                VStack(spacing: 8) {
-                    Image(systemName: "text.badge.plus")
-                        .font(.system(size: 32))
-                        .foregroundColor(.secondary)
-                    Text("Chưa có từ viết tắt")
-                        .font(.system(size: 13))
-                        .foregroundColor(.secondary)
-                    Text("Nhấn + để thêm mới")
-                        .font(.system(size: 11))
-                        .foregroundColor(Color(NSColor.tertiaryLabelColor))
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                Table($appState.shortcuts, selection: $selection) {
-                    TableColumn("Viết tắt") { $item in
-                        ClickableTextField(text: $item.key)
-                    }
-                    .width(min: 60, ideal: 80, max: 100)
-
-                    TableColumn("Nội dung") { $item in
-                        ClickableTextField(text: $item.value)
-                    }
-
-                    TableColumn("Bật") { $item in
-                        Toggle("", isOn: $item.isEnabled)
-                            .labelsHidden()
-                    }
-                    .width(40)
-                }
-                .tableStyle(.inset(alternatesRowBackgrounds: true))
-            }
-
+            tableContent
             Divider()
-
-            // Toolbar - Apple standard: +/- left, actions right
-            HStack(spacing: 0) {
-                Button(action: addShortcut) {
-                    Image(systemName: "plus")
-                        .frame(width: 24, height: 24)
-                }
-                .buttonStyle(.borderless)
-                .help("Thêm")
-
-                Button(action: removeSelected) {
-                    Image(systemName: "minus")
-                        .frame(width: 24, height: 24)
-                }
-                .buttonStyle(.borderless)
-                .disabled(selection.isEmpty)
-                .help("Xoá (Delete)")
-
-                Spacer()
-
-                Button(action: importShortcuts) {
-                    Image(systemName: "square.and.arrow.down")
-                        .frame(width: 24, height: 24)
-                }
-                .buttonStyle(.borderless)
-                .help("Nhập")
-
-                Button(action: exportShortcuts) {
-                    Image(systemName: "square.and.arrow.up")
-                        .frame(width: 24, height: 24)
-                }
-                .buttonStyle(.borderless)
-                .disabled(appState.shortcuts.isEmpty)
-                .help("Xuất")
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
+            toolbar
         }
         .frame(width: 480, height: 420)
-        .onDeleteCommand {
-            if !selection.isEmpty {
-                removeSelected()
+        .onDeleteCommand { if !selection.isEmpty { removeSelected() } }
+        .onDisappear { cleanupEmptyShortcuts() }
+    }
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Từ viết tắt").font(.system(size: 15, weight: .semibold))
+                Text("\(appState.shortcuts.count) mục").font(.system(size: 11)).foregroundColor(.secondary)
             }
+            Spacer()
+            Button("Xong") { dismiss() }.keyboardShortcut(.return, modifiers: [])
         }
-        .onDisappear {
-            // Auto-cleanup empty rows when sheet closes
-            cleanupEmptyShortcuts()
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+    }
+
+    @ViewBuilder
+    private var tableContent: some View {
+        if appState.shortcuts.isEmpty {
+            VStack(spacing: 8) {
+                Image(systemName: "text.badge.plus").font(.system(size: 32)).foregroundColor(.secondary)
+                Text("Chưa có từ viết tắt").font(.system(size: 13)).foregroundColor(.secondary)
+                Text("Nhấn + để thêm mới").font(.system(size: 11)).foregroundColor(Color(NSColor.tertiaryLabelColor))
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            Table($appState.shortcuts, selection: $selection) {
+                TableColumn("Viết tắt") { $item in ClickableTextField(text: $item.key) }.width(min: 60, ideal: 80, max: 100)
+                TableColumn("Nội dung") { $item in ClickableTextField(text: $item.value) }
+                TableColumn("Bật") { $item in Toggle("", isOn: $item.isEnabled).labelsHidden() }.width(40)
+            }
+            .tableStyle(.inset(alternatesRowBackgrounds: true))
         }
+    }
+
+    private var toolbar: some View {
+        HStack(spacing: 0) {
+            Button(action: addShortcut) { Image(systemName: "plus").frame(width: 24, height: 24) }
+                .buttonStyle(.borderless).help("Thêm")
+            Button(action: removeSelected) { Image(systemName: "minus").frame(width: 24, height: 24) }
+                .buttonStyle(.borderless).disabled(selection.isEmpty).help("Xoá (Delete)")
+            Spacer()
+            Button(action: importShortcuts) { Image(systemName: "square.and.arrow.down").frame(width: 24, height: 24) }
+                .buttonStyle(.borderless).help("Nhập")
+            Button(action: exportShortcuts) { Image(systemName: "square.and.arrow.up").frame(width: 24, height: 24) }
+                .buttonStyle(.borderless).disabled(appState.shortcuts.isEmpty).help("Xuất")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
     }
 
     // MARK: - Actions
@@ -879,46 +731,25 @@ struct AboutPageView: View {
     var body: some View {
         VStack(spacing: 24) {
             Spacer()
-
-            // App Info - Centered
             VStack(spacing: 12) {
-                Image(nsImage: AppMetadata.logo)
-                    .resizable()
-                    .frame(width: 80, height: 80)
-
-                Text(AppMetadata.name)
-                    .font(.system(size: 20, weight: .bold))
-
-                Text("Bộ gõ tiếng Việt nhanh và nhẹ")
-                    .font(.system(size: 13))
-                    .foregroundColor(Color(NSColor.secondaryLabelColor))
-
-                Text("Phiên bản \(AppMetadata.version)")
-                    .font(.system(size: 12))
-                    .foregroundColor(Color(NSColor.tertiaryLabelColor))
+                Image(nsImage: AppMetadata.logo).resizable().frame(width: 80, height: 80)
+                Text(AppMetadata.name).font(.system(size: 20, weight: .bold))
+                Text("Bộ gõ tiếng Việt nhanh và nhẹ").font(.system(size: 13)).foregroundColor(Color(NSColor.secondaryLabelColor))
+                Text("Phiên bản \(AppMetadata.version)").font(.system(size: 12)).foregroundColor(Color(NSColor.tertiaryLabelColor))
             }
-
-            // Links - Horizontal buttons
             HStack(spacing: 12) {
                 AboutLink(icon: "chevron.left.forwardslash.chevron.right", title: "GitHub", url: AppMetadata.repository)
                 AboutLink(icon: "ant", title: "Báo lỗi", url: AppMetadata.issuesURL)
                 AboutLink(icon: "heart", title: "Ủng hộ", url: AppMetadata.sponsorURL)
             }
-
             Spacer()
-
-            // Footer
             VStack(spacing: 8) {
                 HStack(spacing: 4) {
-                    Text("Phát triển bởi")
-                        .foregroundColor(Color(NSColor.tertiaryLabelColor))
+                    Text("Phát triển bởi").foregroundColor(Color(NSColor.tertiaryLabelColor))
                     AuthorLink(name: AppMetadata.author, url: AppMetadata.authorLinkedin)
                 }
                 .font(.system(size: 12))
-
-                Text("Từ Việt Nam với ❤️")
-                    .font(.system(size: 11))
-                    .foregroundColor(Color(NSColor.tertiaryLabelColor))
+                Text("Từ Việt Nam với ❤️").font(.system(size: 11)).foregroundColor(Color(NSColor.tertiaryLabelColor))
             }
             .padding(.bottom, 8)
         }
@@ -930,26 +761,17 @@ struct AboutLink: View {
     let icon: String
     let title: String
     let url: String
-
     @State private var hovered = false
 
     var body: some View {
         Link(destination: URL(string: url)!) {
             VStack(spacing: 6) {
-                Image(systemName: icon)
-                    .font(.system(size: 18))
-                Text(title)
-                    .font(.system(size: 11))
+                Image(systemName: icon).font(.system(size: 18))
+                Text(title).font(.system(size: 11))
             }
             .frame(width: 80, height: 60)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(Color(NSColor.controlBackgroundColor).opacity(hovered ? 0.8 : 0.5))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(Color(NSColor.separatorColor).opacity(0.5), lineWidth: 0.5)
-            )
+            .background(RoundedRectangle(cornerRadius: 8).fill(Color(NSColor.controlBackgroundColor).opacity(hovered ? 0.8 : 0.5)))
+            .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color(NSColor.separatorColor).opacity(0.5), lineWidth: 0.5))
         }
         .buttonStyle(.plain)
         .foregroundColor(Color(NSColor.labelColor))
@@ -960,33 +782,27 @@ struct AboutLink: View {
 struct AuthorLink: View {
     let name: String
     let url: String
-
     @State private var hovered = false
 
     var body: some View {
-        Link(destination: URL(string: url)!) {
-            Text(name)
-                .underline(hovered)
-        }
-        .buttonStyle(.plain)
-        .foregroundColor(Color.accentColor)
-        .onHover { hovered = $0 }
+        Link(destination: URL(string: url)!) { Text(name).underline(hovered) }
+            .buttonStyle(.plain)
+            .foregroundColor(Color.accentColor)
+            .onHover { hovered = $0 }
     }
 }
 
 // MARK: - Shortcut Recorder
 
-/// System shortcuts that cannot be overridden by apps
 private let systemShortcuts: Set<String> = [
-    "⌘Space", "⌘⇥", "⌘Q", "⌘W", "⌘H", "⌘M",  // App shortcuts
-    "⌘⇧3", "⌘⇧4", "⌘⇧5",                      // Screenshots
-    "⌃↑", "⌃↓", "⌃←", "⌃→",                    // Spaces navigation
+    "⌘Space", "⌘⇥", "⌘Q", "⌘W", "⌘H", "⌘M",
+    "⌘⇧3", "⌘⇧4", "⌘⇧5",
+    "⌃↑", "⌃↓", "⌃←", "⌃→",
 ]
 
 struct ShortcutRecorderRow: View {
     @Binding var shortcut: KeyboardShortcut
     @Binding var isRecording: Bool
-
     @State private var hovered = false
     @State private var recordedObserver: NSObjectProtocol?
     @State private var cancelledObserver: NSObjectProtocol?
@@ -996,8 +812,7 @@ struct ShortcutRecorderRow: View {
 
     var body: some View {
         HStack {
-            Text("Phím tắt bật/tắt")
-                .font(.system(size: 13))
+            Text("Phím tắt bật/tắt").font(.system(size: 13))
             Spacer()
             shortcutDisplay
         }
@@ -1032,128 +847,24 @@ struct ShortcutRecorderRow: View {
         }
     }
 
-    // MARK: - Recording (CGEventTap-based to capture system shortcuts like Ctrl+Space)
-
     private func startRecording() {
         isRecording = true
-
-        // Listen for shortcut captured via CGEventTap
-        recordedObserver = NotificationCenter.default.addObserver(
-            forName: .shortcutRecorded, object: nil, queue: .main
-        ) { notification in
-            if let captured = notification.object as? KeyboardShortcut {
-                shortcut = captured
-            }
+        recordedObserver = NotificationCenter.default.addObserver(forName: .shortcutRecorded, object: nil, queue: .main) { notification in
+            if let captured = notification.object as? KeyboardShortcut { shortcut = captured }
             stopRecording()
         }
-
-        // Listen for recording cancelled (ESC pressed)
-        cancelledObserver = NotificationCenter.default.addObserver(
-            forName: .shortcutRecordingCancelled, object: nil, queue: .main
-        ) { _ in
-            stopRecording()
-        }
-
-        // Stop recording if window loses focus
-        windowObserver = NotificationCenter.default.addObserver(
-            forName: NSWindow.didResignKeyNotification, object: nil, queue: .main
-        ) { _ in
-            stopRecording()
-        }
-
-        // Start CGEventTap recording mode
+        cancelledObserver = NotificationCenter.default.addObserver(forName: .shortcutRecordingCancelled, object: nil, queue: .main) { _ in stopRecording() }
+        windowObserver = NotificationCenter.default.addObserver(forName: NSWindow.didResignKeyNotification, object: nil, queue: .main) { _ in stopRecording() }
         startShortcutRecording()
     }
 
     private func stopRecording() {
-        // Stop CGEventTap recording mode
         stopShortcutRecording()
-
-        // Remove observers
-        if let observer = recordedObserver {
-            NotificationCenter.default.removeObserver(observer)
-            recordedObserver = nil
-        }
-        if let observer = cancelledObserver {
-            NotificationCenter.default.removeObserver(observer)
-            cancelledObserver = nil
-        }
-        if let observer = windowObserver {
-            NotificationCenter.default.removeObserver(observer)
-            windowObserver = nil
-        }
-
+        [recordedObserver, cancelledObserver, windowObserver].compactMap { $0 }.forEach { NotificationCenter.default.removeObserver($0) }
+        recordedObserver = nil
+        cancelledObserver = nil
+        windowObserver = nil
         isRecording = false
-    }
-}
-
-// MARK: - Reusable Components
-
-struct SectionView<Content: View>: View {
-    let title: String
-    @ViewBuilder let content: Content
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(title)
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(Color(NSColor.secondaryLabelColor))
-                .padding(.horizontal, 4)
-
-            VStack(spacing: 0) {
-                content
-            }
-            .background(
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(Color(NSColor.controlBackgroundColor).opacity(0.5))
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(Color(NSColor.separatorColor).opacity(0.5), lineWidth: 0.5)
-            )
-        }
-    }
-}
-
-struct EmptyStateView: View {
-    let icon: String
-    let text: String
-
-    var body: some View {
-        HStack {
-            Spacer()
-            VStack(spacing: 6) {
-                Image(systemName: icon)
-                    .font(.system(size: 20))
-                    .foregroundColor(Color(NSColor.tertiaryLabelColor))
-                Text(text)
-                    .font(.system(size: 12))
-                    .foregroundColor(Color(NSColor.tertiaryLabelColor))
-            }
-            .padding(.vertical, 20)
-            Spacer()
-        }
-    }
-}
-
-struct KeyCap: View {
-    let text: String
-
-    var body: some View {
-        Text(text)
-            .font(.system(size: 11, weight: .medium))
-            .foregroundColor(Color(NSColor.secondaryLabelColor))
-            .padding(.horizontal, 6)
-            .padding(.vertical, 3)
-            .background(
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(Color(NSColor.controlBackgroundColor).opacity(0.8))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 4)
-                    .stroke(Color(NSColor.separatorColor).opacity(0.5), lineWidth: 0.5)
-            )
     }
 }
 
@@ -1161,70 +872,28 @@ struct KeyCap: View {
 
 struct LaunchAtLoginBanner: View {
     let onOpenSettings: () -> Void
-
     @State private var hovered = false
 
     var body: some View {
         HStack(spacing: 10) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .font(.system(size: 14))
-                .foregroundColor(.orange)
-
+            Image(systemName: "exclamationmark.triangle.fill").font(.system(size: 14)).foregroundColor(.orange)
             VStack(alignment: .leading, spacing: 2) {
-                Text("Chưa bật khởi động cùng hệ thống")
-                    .font(.system(size: 12, weight: .medium))
-                Text("Nhấn để bật")
-                    .font(.system(size: 11))
-                    .foregroundColor(Color(NSColor.secondaryLabelColor))
+                Text("Chưa bật khởi động cùng hệ thống").font(.system(size: 12, weight: .medium))
+                Text("Nhấn để bật").font(.system(size: 11)).foregroundColor(Color(NSColor.secondaryLabelColor))
             }
-
             Spacer()
-
-            Image(systemName: "chevron.right")
-                .font(.system(size: 12, weight: .medium))
-                .foregroundColor(Color(NSColor.tertiaryLabelColor))
+            Image(systemName: "chevron.right").font(.system(size: 12, weight: .medium)).foregroundColor(Color(NSColor.tertiaryLabelColor))
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
-        .background(
-            RoundedRectangle(cornerRadius: 10)
-                .fill(Color.orange.opacity(hovered ? 0.15 : 0.1))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(Color.orange.opacity(0.3), lineWidth: 0.5)
-        )
+        .background(RoundedRectangle(cornerRadius: 10).fill(Color.orange.opacity(hovered ? 0.15 : 0.1)))
+        .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.orange.opacity(0.3), lineWidth: 0.5))
         .contentShape(Rectangle())
-        .onHover { h in
-            hovered = h
-            if h { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-        }
-        .onTapGesture {
-            onOpenSettings()
-        }
-    }
-}
-
-struct VisualEffectBackground: NSViewRepresentable {
-    var material: NSVisualEffectView.Material = .sidebar
-    var blendingMode: NSVisualEffectView.BlendingMode = .behindWindow
-
-    func makeNSView(context: Context) -> NSVisualEffectView {
-        let view = NSVisualEffectView()
-        view.material = material
-        view.blendingMode = blendingMode
-        view.state = .active
-        return view
-    }
-
-    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {
-        nsView.material = material
-        nsView.blendingMode = blendingMode
+        .onHover { h in hovered = h; if h { NSCursor.pointingHand.push() } else { NSCursor.pop() } }
+        .onTapGesture { onOpenSettings() }
     }
 }
 
 // MARK: - Preview
 
-#Preview {
-    MainSettingsView()
-}
+#Preview { MainSettingsView() }


### PR DESCRIPTION
Replace VStack + ForEach with ScrollView + LazyVStack to enable
lazy loading. Only visible rows are rendered, fixing lag with
large shortcut lists (1000+ items).