### PR TITLE
Fix issue and add test cases

### DIFF
--- a/core/tests/typing_test.rs
+++ b/core/tests/typing_test.rs
@@ -166,6 +166,12 @@ const TELEX_TYPOS: &[(&str, &str)] = &[
     ("ejo", "ẹo"),     // e + j + o → ẹo
     ("keso", "kéo"),   // k + e + s + o → kéo
     ("treso", "tréo"), // tr + e + s + o → tréo
+    // Issue #48: dd + eso pattern (đ + e + s + o → đéo)
+    ("ddeso", "đéo"),   // dd + e + s + o → đéo
+    ("ddefo", "đèo"),   // dd + e + f + o → đèo (đèo = mountain pass)
+    ("ddero", "đẻo"),   // dd + e + r + o → đẻo
+    ("ddexo", "đẽo"),   // dd + e + x + o → đẽo
+    ("ddejo", "đẹo"),   // dd + e + j + o → đẹo
     //
     // --- Pattern: êu (ê + glide u) ---
     ("eesu", "ếu"),   // ee + s + u → ếu (ee = ê)


### PR DESCRIPTION
… (issue #48)

When typing "ddeso", the engine was incorrectly detecting "de" + "s" as an English word pattern (like "describe", "design") and skipping the mark transformation. This resulted in "đeso" instead of "đéo".

The fix adds a check for stroke transforms (đ) in addition to horn transforms. If a stroke has been applied, it indicates intentional Vietnamese typing, so foreign word detection should be skipped.

Also adds test cases for dd + eo patterns with all tone marks.

## Mô tả
<!-- PR này làm gì? -->

## Loại thay đổi
- [ ] 🐛 Sửa lỗi
- [ ] ✨ Tính năng mới
- [ ] 📝 Tài liệu
- [ ] ♻️ Refactor

## Checklist
- [ ] Tests pass (`cargo test`)
- [ ] Code formatted (`cargo fmt`)
- [ ] Không có clippy warnings
