### PR TITLE
fix(core): respect modern_tone setting when repositioning tone

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -1033,7 +1033,8 @@ impl Engine {
             let has_final = self.has_final_consonant(last_vowel_pos);
             let has_qu = self.has_qu_initial();
             let has_gi = self.has_gi_initial();
-            let new_pos = Phonology::find_tone_position(&vowels, has_final, true, has_qu, has_gi);
+            let new_pos =
+                Phonology::find_tone_position(&vowels, has_final, self.modern_tone, has_qu, has_gi);
 
             if new_pos != old_pos {
                 // Move tone from old position to new position

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -290,6 +290,35 @@ mod test_utils {
         }
     }
 
+    /// Run Telex test cases with traditional tone placement (hòa, thúy style)
+    pub fn telex_traditional(cases: &[(&str, &str)]) {
+        for (input, expected) in cases {
+            let mut e = Engine::new();
+            e.set_modern_tone(false);
+            let result = type_word(&mut e, input);
+            assert_eq!(
+                result, *expected,
+                "[Telex Traditional] '{}' → '{}'",
+                input, result
+            );
+        }
+    }
+
+    /// Run VNI test cases with traditional tone placement (hòa, thúy style)
+    pub fn vni_traditional(cases: &[(&str, &str)]) {
+        for (input, expected) in cases {
+            let mut e = Engine::new();
+            e.set_method(1);
+            e.set_modern_tone(false);
+            let result = type_word(&mut e, input);
+            assert_eq!(
+                result, *expected,
+                "[VNI Traditional] '{}' → '{}'",
+                input, result
+            );
+        }
+    }
+
     /// Simulate typing with extended parameters (supports raw mode prefix)
     /// Input format: use special prefixes to trigger shift+key:
     /// - "@" triggers Shift+2

--- a/core/tests/common/mod.rs
+++ b/core/tests/common/mod.rs
@@ -7,7 +7,7 @@
 #![allow(unused_imports)]
 
 // Re-export core test utilities
-pub use gonhanh_core::utils::{telex, type_word, vni};
+pub use gonhanh_core::utils::{telex, telex_traditional, type_word, vni, vni_traditional};
 
 use gonhanh_core::engine::{Action, Engine};
 

--- a/core/tests/typing_test.rs
+++ b/core/tests/typing_test.rs
@@ -1,7 +1,7 @@
 //! Typing Tests - Real-world typing scenarios, sentences, behaviors
 
 mod common;
-use common::{telex, vni};
+use common::{telex, telex_traditional, vni, vni_traditional};
 
 // ============================================================
 // BACKSPACE & CORRECTIONS
@@ -1424,4 +1424,118 @@ fn telex_english_aw_words() {
 #[ignore = "Issue #44: pending breve deferral feature"]
 fn telex_breve_edge_cases() {
     telex(TELEX_BREVE_EDGE_CASES);
+}
+
+// ============================================================
+// TRADITIONAL TONE PLACEMENT - Issue #64
+// ============================================================
+//
+// When "modern tone" setting is OFF (traditional style):
+// - hòa, thúy (tone on 1st vowel) instead of hoà, thuý (tone on 2nd)
+//
+// Bug: Even with setting OFF, out-of-order typing (e.g., "xosa", "tufy")
+// still produces modern-style results due to hardcoded `true` in
+// `reposition_tone_if_needed()` function.
+
+const TELEX_TRADITIONAL_TONE: &[(&str, &str)] = &[
+    // ============================================================
+    // Issue #64: Out-of-order typing with traditional tone setting
+    // When typing tone BEFORE the second vowel, then adding second vowel,
+    // tone should stay on FIRST vowel in traditional mode
+    // ============================================================
+    //
+    // --- Pattern: oa (traditional: tone on 'o') ---
+    ("osa", "óa"),     // o + s + a → óa (NOT oá)
+    ("ofa", "òa"),     // o + f + a → òa (NOT oà)
+    ("ora", "ỏa"),     // o + r + a → ỏa (NOT oả)
+    ("oxa", "õa"),     // o + x + a → õa (NOT oã)
+    ("oja", "ọa"),     // o + j + a → ọa (NOT oạ)
+    ("hosa", "hóa"),   // h + o + s + a → hóa (NOT hoá)
+    ("hofa", "hòa"),   // h + o + f + a → hòa (NOT hoà)
+    ("xosa", "xóa"),   // x + o + s + a → xóa (NOT xoá) - Issue #64 case
+    ("losa", "lóa"),   // l + o + s + a → lóa (NOT loá)
+    ("tosa", "tóa"),   // t + o + s + a → tóa (NOT toá)
+    //
+    // --- Pattern: oe (traditional: tone on 'o') ---
+    ("ose", "óe"),     // o + s + e → óe (NOT oé)
+    ("ofe", "òe"),     // o + f + e → òe (NOT oè)
+    ("khose", "khóe"), // kh + o + s + e → khóe (NOT khoé)
+    ("xose", "xóe"),   // x + o + s + e → xóe (NOT xoé)
+    //
+    // --- Pattern: uy (traditional: tone on 'u') ---
+    ("usy", "úy"),     // u + s + y → úy (NOT uý)
+    ("ufy", "ùy"),     // u + f + y → ùy (NOT uỳ)
+    ("ury", "ủy"),     // u + r + y → ủy (NOT uỷ)
+    ("uxy", "ũy"),     // u + x + y → ũy (NOT uỹ)
+    ("ujy", "ụy"),     // u + j + y → ụy (NOT uỵ)
+    ("tusy", "túy"),   // t + u + s + y → túy (NOT tuý)
+    ("tufy", "tùy"),   // t + u + f + y → tùy (NOT tuỳ) - Issue #64 case
+    ("husy", "húy"),   // h + u + s + y → húy (NOT huý)
+    ("thusy", "thúy"), // th + u + s + y → thúy (NOT thuý)
+    //
+    // --- qu- special case (always tone on 2nd vowel regardless) ---
+    // qu is treated as initial, so 'u' is not the vowel
+    ("qusy", "quý"), // qu + s + y → quý (same in both modes)
+    //
+    // ============================================================
+    // Delayed tone (typing tone AFTER all vowels) - should also respect setting
+    // ============================================================
+    //
+    // --- oa + delayed tone ---
+    ("hoas", "hóa"),   // h + o + a + s → hóa (traditional)
+    ("hoaf", "hòa"),   // h + o + a + f → hòa (traditional)
+    ("xoas", "xóa"),   // x + o + a + s → xóa (traditional)
+    //
+    // --- oe + delayed tone ---
+    ("khoes", "khóe"), // kh + o + e + s → khóe (traditional)
+    //
+    // --- uy + delayed tone ---
+    ("tuys", "túy"),   // t + u + y + s → túy (traditional)
+    ("tuyf", "tùy"),   // t + u + y + f → tùy (traditional)
+    ("thuys", "thúy"), // th + u + y + s → thúy (traditional)
+    //
+    // ============================================================
+    // Normal order (tone typed correctly) - for comparison
+    // ============================================================
+    ("hosa", "hóa"),   // same as above
+    ("thusa", "thúa"), // th + u + s + a → thúa (u is main vowel, a is glide)
+];
+
+const VNI_TRADITIONAL_TONE: &[(&str, &str)] = &[
+    // ============================================================
+    // Issue #64: VNI with traditional tone setting
+    // ============================================================
+    //
+    // --- Pattern: oa (traditional: tone on 'o') ---
+    ("o1a", "óa"),   // o + 1 + a → óa (NOT oá)
+    ("o2a", "òa"),   // o + 2 + a → òa (NOT oà)
+    ("ho1a", "hóa"), // h + o + 1 + a → hóa (NOT hoá)
+    ("ho2a", "hòa"), // h + o + 2 + a → hòa (NOT hoà)
+    ("xo1a", "xóa"), // x + o + 1 + a → xóa (NOT xoá) - Issue #64 case
+    //
+    // --- Pattern: oe (traditional: tone on 'o') ---
+    ("o1e", "óe"),     // o + 1 + e → óe (NOT oé)
+    ("kho1e", "khóe"), // kh + o + 1 + e → khóe (NOT khoé)
+    //
+    // --- Pattern: uy (traditional: tone on 'u') ---
+    ("u1y", "úy"),   // u + 1 + y → úy (NOT uý)
+    ("u2y", "ùy"),   // u + 2 + y → ùy (NOT uỳ)
+    ("tu1y", "túy"), // t + u + 1 + y → túy (NOT tuý)
+    ("tu2y", "tùy"), // t + u + 2 + y → tùy (NOT tuỳ) - Issue #64 case
+    //
+    // --- Delayed tone ---
+    ("hoa1", "hóa"), // h + o + a + 1 → hóa (traditional)
+    ("hoa2", "hòa"), // h + o + a + 2 → hòa (traditional)
+    ("tuy1", "túy"), // t + u + y + 1 → túy (traditional)
+    ("tuy2", "tùy"), // t + u + y + 2 → tùy (traditional)
+];
+
+#[test]
+fn telex_traditional_tone_placement() {
+    telex_traditional(TELEX_TRADITIONAL_TONE);
+}
+
+#[test]
+fn vni_traditional_tone_placement() {
+    vni_traditional(VNI_TRADITIONAL_TONE);
 }


### PR DESCRIPTION
## Summary

- Fix bug where out-of-order typing ignored the "modern tone" setting
- Add test cases for traditional tone placement with Telex and VNI

## Problem

When user disables "đặt dấu kiểu mới oà uý" setting, typing out-of-order (e.g., `xosa`, `tufy`) still produces modern-style results:
- `xosa` → `xoá` (modern) instead of `xóa` (traditional)
- `tufy` → `tuỳ` (modern) instead of `tùy` (traditional)

## Root Cause

In `reposition_tone_if_needed()` function at line 1036, the `modern` parameter was hardcoded to `true`:

```rust
// Before (bug)
let new_pos = Phonology::find_tone_position(&vowels, has_final, true, has_qu, has_gi);

// After (fix)
let new_pos = Phonology::find_tone_position(&vowels, has_final, self.modern_tone, has_qu, has_gi);
```

## Test plan

- [x] Add test cases for traditional tone placement (Telex)
- [x] Add test cases for traditional tone placement (VNI)
- [x] All existing tests pass

Fixes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)