### PR TITLE
feat(macos): add selectAll injection method for Spotlight/Arc

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -1365,6 +1365,13 @@ impl Engine {
         self.has_non_letter_prefix = false;
     }
 
+    /// Get the full composed buffer as a Vietnamese string with diacritics.
+    ///
+    /// Used for "Select All + Replace" injection method.
+    pub fn get_buffer_string(&self) -> String {
+        self.buf.to_full_string()
+    }
+
     /// Restore buffer from a Vietnamese word string
     ///
     /// Used when native app detects cursor at word boundary and wants to edit.


### PR DESCRIPTION
## Summary

- Add new `selectAll` text injection method that selects all text then types full buffer
- Use this method for Spotlight on macOS 13 and earlier (fixes autocomplete issues)
- Use this method for Arc browser address bar
- Optimize `detectMethod()` to be called once per keystroke instead of 3 times

## Details

The existing autocomplete method (Forward Delete + Backspace + type) doesn't work well on:
- **Spotlight on macOS 13**: The autocomplete behavior changed and breaks Vietnamese input
- **Arc browser**: Aggressive autocomplete interferes with text replacement

The new `selectAll` method:
1. Tracks a session buffer with all typed text
2. On each keystroke, selects all text using `Cmd+Left` + `Shift+Cmd+Right`
3. Types the full session buffer to replace selected text
4. Handles Cmd shortcuts (A/V/X/Z) by syncing session buffer after action
5. Handles backspace by either removing from buffer or passing through

## Test plan

- [ ] Test Vietnamese typing in Spotlight on macOS 13
- [ ] Test Vietnamese typing in Arc browser address bar
- [ ] Test Cmd+A, Cmd+V, Cmd+X, Cmd+Z work correctly
- [ ] Test backspace works correctly (deletes char, or deletes selection after Cmd+A)
- [ ] Test normal typing in other apps still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)