### PR TITLE
fix(macos): require exact modifier match for toggle shortcut

### DIFF
--- a/platforms/macos/RustBridge.swift
+++ b/platforms/macos/RustBridge.swift
@@ -634,9 +634,9 @@ func setupShortcutObserver() {
 private func matchesToggleShortcut(keyCode: UInt16, flags: CGEventFlags) -> Bool {
     guard currentShortcut.keyCode != 0xFFFF, keyCode == currentShortcut.keyCode else { return false }
     let saved = CGEventFlags(rawValue: currentShortcut.modifiers)
-    let required: [CGEventFlags] = [.maskControl, .maskAlternate, .maskShift, .maskCommand]
-    for mod in required where saved.contains(mod) && !flags.contains(mod) { return false }
-    return !(!saved.contains(.maskCommand) && flags.contains(.maskCommand))
+    // Exact match: only the saved modifiers should be pressed, no extras
+    // e.g., Ctrl+Space should NOT match Ctrl+Option+Space
+    return flags.intersection(kModifierMask) == saved.intersection(kModifierMask)
 }
 
 private func matchesModifierOnlyShortcut(flags: CGEventFlags) -> Bool {


### PR DESCRIPTION
## Summary
- Fix phím tắt chuyển đổi ngôn ngữ trigger không chính xác khi có modifier thừa
- Ví dụ: Ctrl+Z được cấu hình nhưng Ctrl+Shift+Z cũng trigger (không mong muốn)

## Changes
- Sử dụng `flags.intersection(kModifierMask) == saved.intersection(kModifierMask)` để đảm bảo chỉ đúng các modifier được cấu hình mới trigger

## Test plan
- [x] Cấu hình phím tắt Ctrl+Z
- [x] Nhấn Ctrl+Z → Phải chuyển đổi ngôn ngữ
- [x] Nhấn Ctrl+Shift+Z → Không được chuyển đổi ngôn ngữ