### PR TITLE
fix: correct double mark key revert to output single character

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -173,6 +173,9 @@ pub struct Engine {
     /// Breve on 'a' in open syllables (like "raw") is invalid Vietnamese
     /// We defer applying breve until a valid final consonant is typed
     pending_breve_pos: Option<usize>,
+    /// Tracks if a mark was reverted in current word
+    /// Used by auto-restore to detect words like "issue", "bass" that need restoration
+    had_mark_revert: bool,
 }
 
 impl Default for Engine {
@@ -199,6 +202,7 @@ impl Engine {
             word_history: WordHistory::new(),
             spaces_after_commit: 0,
             pending_breve_pos: None,
+            had_mark_revert: false,
         }
     }
 
@@ -1551,32 +1555,24 @@ impl Engine {
     }
 
     /// Revert mark transformation
-    /// When mark is reverted, both the original mark key AND the reverting key
-    /// should appear as letters. Example: "iss" → "is" is wrong, should be "iss"
+    /// When mark is reverted, only the reverting key appears as a letter.
+    /// Standard behavior: "ass" → "as" (first 's' was modifier, second 's' reverts + outputs one 's')
+    /// This matches standard Vietnamese IME behavior (UniKey, ibus-unikey, etc.)
     fn revert_mark(&mut self, key: u16, caps: bool) -> Result {
         self.last_transform = None;
+        self.had_mark_revert = true; // Track for auto-restore
 
         for pos in self.buf.find_vowels().into_iter().rev() {
             if let Some(c) = self.buf.get_mut(pos) {
                 if c.mark > mark::NONE {
                     c.mark = mark::NONE;
 
-                    // Find the original mark key's caps state from raw_input
-                    // The original mark key is second-to-last in raw_input
-                    // (last one is the current reverting key)
-                    let orig_caps = if self.raw_input.len() >= 2 {
-                        self.raw_input[self.raw_input.len() - 2].1
-                    } else {
-                        caps
-                    };
-
-                    // Add original mark key first (it was consumed as modifier before)
-                    self.buf.push(Char::new(key, orig_caps));
-                    // Then add the current reverting key
+                    // Add only the reverting key (current key being pressed)
+                    // The original mark key was consumed as a modifier and doesn't produce output
                     self.buf.push(Char::new(key, caps));
 
                     // Calculate backspace and output
-                    let backspace = (self.buf.len() - pos - 2) as u8; // -2 because we added 2 chars
+                    let backspace = (self.buf.len() - pos - 1) as u8; // -1 because we added 1 char
                     let output: Vec<char> = (pos..self.buf.len())
                         .filter_map(|i| self.buf.get(i))
                         .filter_map(|c| utils::key_to_char(c.key, c.caps))
@@ -1929,6 +1925,7 @@ impl Engine {
         self.last_transform = None;
         self.has_non_letter_prefix = false;
         self.pending_breve_pos = None;
+        self.had_mark_revert = false;
     }
 
     /// Get the full composed buffer as a Vietnamese string with diacritics.
@@ -1975,11 +1972,13 @@ impl Engine {
         // - Marks (sắc, huyền, hỏi, ngã, nặng): indicate Vietnamese typing intent
         // - Vowel tones (â, ê, ô, ư, ă): indicate Vietnamese typing intent
         // - Stroke (đ): included for longer words that are structurally invalid
+        // - Mark revert: indicates user typed double mark key (e.g., "ss" -> "s")
+        //   This is tracked via had_mark_revert flag, not length mismatch
         let has_marks_or_tones = self.buf.iter().any(|c| c.tone > 0 || c.mark > 0);
         let has_stroke = self.buf.iter().any(|c| c.stroke);
 
-        // If no transforms at all, nothing to restore
-        if !has_marks_or_tones && !has_stroke {
+        // If no transforms at all (including mark revert), nothing to restore
+        if !has_marks_or_tones && !has_stroke && !self.had_mark_revert {
             return None;
         }
 

--- a/core/tests/engine_test.rs
+++ b/core/tests/engine_test.rs
@@ -352,15 +352,16 @@ fn revert_tone_double_key() {
 
 #[test]
 fn revert_mark_double_key() {
-    // When mark is reverted, BOTH the original mark key AND the reverting key
-    // should appear as letters. This allows typing words like "issue", "bass", etc.
-    // ass → ass (not as): first 's' was modifier for á, second 's' reverts and outputs both
+    // When mark is reverted, only the reverting key appears as a letter.
+    // Standard behavior: first key was modifier, second key reverts and outputs one letter.
+    // This allows typing words like "test" (tesst), "next" (nexxt), etc.
+    // ass → as: first 's' was modifier for á, second 's' reverts and outputs one 's'
     telex(&[
-        ("ass", "ass"),
-        ("aff", "aff"),
-        ("arr", "arr"),
-        ("axx", "axx"),
-        ("ajj", "ajj"),
+        ("ass", "as"),
+        ("aff", "af"),
+        ("arr", "ar"),
+        ("axx", "ax"),
+        ("ajj", "aj"),
     ]);
 }
 

--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -309,9 +309,11 @@ fn modern_orthography_full() {
 
 #[test]
 fn double_mark_key_includes_both() {
-    // When mark is reverted by pressing same key twice, BOTH keys appear as letters
-    // This allows typing English words like "issue", "bass", "boss"
-    telex(&[("ass", "ass")]);
+    // When mark is reverted by pressing same key twice, only the reverting key appears
+    // This is standard Vietnamese IME behavior (UniKey, ibus-unikey, etc.)
+    // First key was modifier, second key reverts and outputs one letter
+    // English words like "issue", "bass" work via auto-restore feature
+    telex(&[("ass", "as")]);
 }
 
 #[test]
@@ -428,14 +430,14 @@ fn foreign_word_exxpe_no_transform() {
     // When typing "exxpe":
     // - 'e' → buffer="e"
     // - 'x' → mark applied → screen="ẽ"
-    // - 'x' → revert (same key) → screen="exx", buffer="exx" (both x appear)
-    // - 'p' → screen="exxp", buffer="exxp"
-    // - 'e' → buffer="exxpe" invalid → no circumflex applied, just adds 'e'
-    // Result: "exxpe" (both x keys appear after revert)
+    // - 'x' → revert (same key) → screen="ex", buffer="ex" (only reverting key appears)
+    // - 'p' → screen="exp", buffer="exp"
+    // - 'e' → buffer="expe" invalid → no circumflex applied, just adds 'e'
+    // Result: "expe" (standard IME behavior: first x was modifier, second x reverts)
     let result = type_word(&mut e, "exxpe");
     assert_eq!(
-        result, "exxpe",
-        "exxpe should stay exxpe (both x keys appear after revert), got: {}",
+        result, "expe",
+        "exxpe should become expe (standard IME revert behavior), got: {}",
         result
     );
 }

--- a/core/tests/permutation_test.rs
+++ b/core/tests/permutation_test.rs
@@ -312,13 +312,14 @@ fn modifier_after_initial() {
 }
 
 /// Double modifiers (revert behavior)
-/// When mark is reverted, BOTH keys appear as letters (for English words)
+/// When mark is reverted, only the reverting key appears (standard IME behavior)
+/// For English words like "mass", "maff", use auto-restore feature
 #[test]
 fn double_modifiers() {
     telex(&[
-        // Double mark should revert AND include both keys
-        ("mass ", "mass "), // second s reverts sắc, both s appear
-        ("maff ", "maff "), // second f reverts huyền, both f appear
+        // Double mark: first key is modifier, second reverts and outputs ONE key
+        ("mass ", "mas "), // second s reverts sắc, one s appears
+        ("maff ", "maf "), // second f reverts huyền, one f appears
     ]);
 }
 

--- a/core/tests/typing_test.rs
+++ b/core/tests/typing_test.rs
@@ -364,10 +364,10 @@ const TELEX_TYPOS: &[(&str, &str)] = &[
     // EXISTING TEST CASES (preserved)
     // ============================================================
     //
-    // Double mark → revert (both keys appear for English words)
-    ("ass", "ass"),
-    ("aff", "aff"),
-    ("arr", "arr"),
+    // Double mark → revert (only reverting key appears - standard IME behavior)
+    ("ass", "as"),
+    ("aff", "af"),
+    ("arr", "ar"),
     // Double tone → revert
     ("aaa", "aa"),
     ("ooo", "oo"),
@@ -669,7 +669,7 @@ const TELEX_COMMON_ISSUES: &[(&str, &str)] = &[
     ("sa", "sa"),
     ("as", "á"),
     ("sas", "sá"),
-    ("sass", "sass"), // both s appear after revert
+    ("sass", "sas"), // first s modifier for sắc, second s reverts + outputs one s
     ("fa", "fa"),
     ("af", "à"),
     // Long compound words

--- a/core/tests/unit_test.rs
+++ b/core/tests/unit_test.rs
@@ -103,12 +103,13 @@ const TELEX_MODIFIED_VOWELS: &[(&str, &str)] = &[
 ];
 
 const TELEX_REVERT: &[(&str, &str)] = &[
-    // Mark revert (both keys appear for English words)
-    ("ass", "ass"),
-    ("aff", "aff"),
-    ("arr", "arr"),
-    ("axx", "axx"),
-    ("ajj", "ajj"),
+    // Mark revert (only reverting key appears - standard IME behavior)
+    // First key is modifier, second key reverts and outputs one letter
+    ("ass", "as"),
+    ("aff", "af"),
+    ("arr", "ar"),
+    ("axx", "ax"),
+    ("ajj", "aj"),
     // Tone revert
     ("aaa", "aa"),
     ("eee", "ee"),
@@ -248,12 +249,12 @@ const VNI_MODIFIED_VOWELS: &[(&str, &str)] = &[
 ];
 
 const VNI_REVERT: &[(&str, &str)] = &[
-    // Mark revert (both keys appear)
-    ("a11", "a11"),
-    ("a22", "a22"),
-    ("a33", "a33"),
-    ("a44", "a44"),
-    ("a55", "a55"),
+    // Mark revert (only reverting key appears - standard IME behavior)
+    ("a11", "a1"),
+    ("a22", "a2"),
+    ("a33", "a3"),
+    ("a44", "a4"),
+    ("a55", "a5"),
     // Tone revert (single key)
     ("a66", "a6"),
     ("e66", "e6"),


### PR DESCRIPTION
## Description

Khi gõ phím dấu thanh (s, f, r, x, j) hai lần liên tiếp để hủy dấu, kết quả không đúng:

| Input | Actual | Expected |
|-------|--------|----------|
| `tesst` | `tesst` | `test` |
| `Exx` | `Exx` | `Ex` |
| `nexxt` | `nexxt` | `next` |

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Root Cause

Trong `core/src/engine/mod.rs`, hàm `revert_mark` thêm **2 ký tự** vào buffer khi revert, trong khi hành vi tiêu chuẩn của các bộ gõ tiếng Việt (UniKey, ibus-unikey) chỉ nên thêm **1 ký tự**.

## Solution

Sửa `revert_mark` để chỉ thêm 1 ký tự (phím vừa gõ). Thêm flag `had_mark_revert` để hỗ trợ tính năng `english_auto_restore`.

## Testing

```bash
cd core
cargo test