### PR TITLE
fix: alternative approach for double mark key revert

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -1551,8 +1551,7 @@ impl Engine {
     }
 
     /// Revert mark transformation
-    /// When mark is reverted, both the original mark key AND the reverting key
-    /// should appear as letters. Example: "iss" → "is" is wrong, should be "iss"
+    /// Second mark key cancels the mark, leaving one letter (consistent with revert_tone)
     fn revert_mark(&mut self, key: u16, caps: bool) -> Result {
         self.last_transform = None;
 
@@ -1560,29 +1559,7 @@ impl Engine {
             if let Some(c) = self.buf.get_mut(pos) {
                 if c.mark > mark::NONE {
                     c.mark = mark::NONE;
-
-                    // Find the original mark key's caps state from raw_input
-                    // The original mark key is second-to-last in raw_input
-                    // (last one is the current reverting key)
-                    let orig_caps = if self.raw_input.len() >= 2 {
-                        self.raw_input[self.raw_input.len() - 2].1
-                    } else {
-                        caps
-                    };
-
-                    // Add original mark key first (it was consumed as modifier before)
-                    self.buf.push(Char::new(key, orig_caps));
-                    // Then add the current reverting key
-                    self.buf.push(Char::new(key, caps));
-
-                    // Calculate backspace and output
-                    let backspace = (self.buf.len() - pos - 2) as u8; // -2 because we added 2 chars
-                    let output: Vec<char> = (pos..self.buf.len())
-                        .filter_map(|i| self.buf.get(i))
-                        .filter_map(|c| utils::key_to_char(c.key, c.caps))
-                        .collect();
-
-                    return Result::send(backspace, &output);
+                    return self.revert_and_rebuild(pos, key, caps);
                 }
             }
         }
@@ -1978,8 +1955,17 @@ impl Engine {
         let has_marks_or_tones = self.buf.iter().any(|c| c.tone > 0 || c.mark > 0);
         let has_stroke = self.buf.iter().any(|c| c.stroke);
 
-        // If no transforms at all, nothing to restore
-        if !has_marks_or_tones && !has_stroke {
+        // Check if mark revert happened: buffer is shorter than raw_input
+        // AND raw_input contains mark keys (s/f/r/x/j in Telex)
+        // This excludes tone reverts like "aaa" → "aa" which should NOT trigger auto-restore
+        // NOTE: This only covers Telex. VNI mark keys (1-5) are NOT included.
+        // For full VNI support, use PR #73's had_mark_revert flag approach instead.
+        let mark_keys = [keys::S, keys::F, keys::R, keys::X, keys::J];
+        let raw_has_mark_keys = self.raw_input.iter().any(|&(k, _)| mark_keys.contains(&k));
+        let had_mark_revert = self.buf.len() < self.raw_input.len() && raw_has_mark_keys;
+
+        // If no transforms AND no mark revert, nothing to restore
+        if !has_marks_or_tones && !has_stroke && !had_mark_revert {
             return None;
         }
 

--- a/core/tests/engine_test.rs
+++ b/core/tests/engine_test.rs
@@ -352,15 +352,14 @@ fn revert_tone_double_key() {
 
 #[test]
 fn revert_mark_double_key() {
-    // When mark is reverted, BOTH the original mark key AND the reverting key
-    // should appear as letters. This allows typing words like "issue", "bass", etc.
-    // ass → ass (not as): first 's' was modifier for á, second 's' reverts and outputs both
+    // Second mark key cancels the mark, leaving one letter (consistent with revert_tone)
+    // ass → as: first 's' was modifier for á, second 's' reverts and outputs one 's'
     telex(&[
-        ("ass", "ass"),
-        ("aff", "aff"),
-        ("arr", "arr"),
-        ("axx", "axx"),
-        ("ajj", "ajj"),
+        ("ass", "as"),
+        ("aff", "af"),
+        ("arr", "ar"),
+        ("axx", "ax"),
+        ("ajj", "aj"),
     ]);
 }
 

--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -308,10 +308,10 @@ fn modern_orthography_full() {
 // ============================================================
 
 #[test]
-fn double_mark_key_includes_both() {
-    // When mark is reverted by pressing same key twice, BOTH keys appear as letters
-    // This allows typing English words like "issue", "bass", "boss"
-    telex(&[("ass", "ass")]);
+fn double_mark_key_reverts_to_single() {
+    // When mark is reverted by pressing same key twice, only ONE key appears
+    // English words like "issue", "bass" work via auto-restore feature on space
+    telex(&[("ass", "as")]);
 }
 
 #[test]
@@ -423,19 +423,19 @@ fn foreign_word_exp_no_circumflex() {
 }
 
 #[test]
-fn foreign_word_exxpe_no_transform() {
+fn foreign_word_exxpe_revert_behavior() {
     let mut e = Engine::new();
     // When typing "exxpe":
     // - 'e' → buffer="e"
     // - 'x' → mark applied → screen="ẽ"
-    // - 'x' → revert (same key) → screen="exx", buffer="exx" (both x appear)
-    // - 'p' → screen="exxp", buffer="exxp"
-    // - 'e' → buffer="exxpe" invalid → no circumflex applied, just adds 'e'
-    // Result: "exxpe" (both x keys appear after revert)
+    // - 'x' → revert (same key) → screen="ex", buffer="ex" (only reverting key appears)
+    // - 'p' → screen="exp", buffer="exp"
+    // - 'e' → buffer="expe" invalid → no circumflex applied, just adds 'e'
+    // Result: "expe" (standard revert behavior: first x was modifier, second x reverts)
     let result = type_word(&mut e, "exxpe");
     assert_eq!(
-        result, "exxpe",
-        "exxpe should stay exxpe (both x keys appear after revert), got: {}",
+        result, "expe",
+        "exxpe should become expe (standard revert behavior), got: {}",
         result
     );
 }

--- a/core/tests/permutation_test.rs
+++ b/core/tests/permutation_test.rs
@@ -312,13 +312,14 @@ fn modifier_after_initial() {
 }
 
 /// Double modifiers (revert behavior)
-/// When mark is reverted, BOTH keys appear as letters (for English words)
+/// Second mark key cancels the mark, leaving one letter
+/// For full English words like "mass", auto-restore handles it on space/break
 #[test]
 fn double_modifiers() {
     telex(&[
-        // Double mark should revert AND include both keys
-        ("mass ", "mass "), // second s reverts sắc, both s appear
-        ("maff ", "maff "), // second f reverts huyền, both f appear
+        // Double mark = cancel, produces single letter (not both)
+        ("mass ", "mas "), // second s cancels sắc, single s remains
+        ("maff ", "maf "), // second f cancels huyền, single f remains
     ]);
 }
 

--- a/core/tests/typing_test.rs
+++ b/core/tests/typing_test.rs
@@ -364,10 +364,10 @@ const TELEX_TYPOS: &[(&str, &str)] = &[
     // EXISTING TEST CASES (preserved)
     // ============================================================
     //
-    // Double mark → revert (both keys appear for English words)
-    ("ass", "ass"),
-    ("aff", "aff"),
-    ("arr", "arr"),
+    // Double mark → revert (only reverting key appears - standard IME behavior)
+    ("ass", "as"),
+    ("aff", "af"),
+    ("arr", "ar"),
     // Double tone → revert
     ("aaa", "aa"),
     ("ooo", "oo"),
@@ -669,7 +669,7 @@ const TELEX_COMMON_ISSUES: &[(&str, &str)] = &[
     ("sa", "sa"),
     ("as", "á"),
     ("sas", "sá"),
-    ("sass", "sass"), // both s appear after revert
+    ("sass", "sas"), // second s reverts, single s remains
     ("fa", "fa"),
     ("af", "à"),
     // Long compound words

--- a/core/tests/unit_test.rs
+++ b/core/tests/unit_test.rs
@@ -103,12 +103,12 @@ const TELEX_MODIFIED_VOWELS: &[(&str, &str)] = &[
 ];
 
 const TELEX_REVERT: &[(&str, &str)] = &[
-    // Mark revert (both keys appear for English words)
-    ("ass", "ass"),
-    ("aff", "aff"),
-    ("arr", "arr"),
-    ("axx", "axx"),
-    ("ajj", "ajj"),
+    // Mark revert (second key cancels mark, single key remains)
+    ("ass", "as"),
+    ("aff", "af"),
+    ("arr", "ar"),
+    ("axx", "ax"),
+    ("ajj", "aj"),
     // Tone revert
     ("aaa", "aa"),
     ("eee", "ee"),
@@ -248,12 +248,12 @@ const VNI_MODIFIED_VOWELS: &[(&str, &str)] = &[
 ];
 
 const VNI_REVERT: &[(&str, &str)] = &[
-    // Mark revert (both keys appear)
-    ("a11", "a11"),
-    ("a22", "a22"),
-    ("a33", "a33"),
-    ("a44", "a44"),
-    ("a55", "a55"),
+    // Mark revert (second key cancels mark, single key remains)
+    ("a11", "a1"),
+    ("a22", "a2"),
+    ("a33", "a3"),
+    ("a44", "a4"),
+    ("a55", "a5"),
     // Tone revert (single key)
     ("a66", "a6"),
     ("e66", "e6"),


### PR DESCRIPTION
## Description

Alternative approach to PR #73 for fixing double mark key revert behavior.

| Input | Before | After |
|-------|--------|-------|
| `tesst` | `tesst` | `test` (via auto-restore) |
| `ass` | `ass` | `as` |
| `Exx` | `Exx` | `Ex` |

## Approach

Uses buffer length comparison instead of explicit `had_mark_revert` flag:

```rust
let mark_keys = [keys::S, keys::F, keys::R, keys::X, keys::J];
let raw_has_mark_keys = self.raw_input.iter().any(|&(k, _)| mark_keys.contains(&k));
let had_mark_revert = self.buf.len() < self.raw_input.len() && raw_has_mark_keys;
```

## ⚠️ Limitation

**Only covers Telex.** VNI mark keys (1-5) are NOT included in detection.

For full VNI support, use PR #73's `had_mark_revert` flag approach instead.

## Comparison with PR #73

| Aspect | This PR | PR #73 |
|--------|---------|--------|
| Telex coverage | ✅ | ✅ |
| VNI coverage | ❌ | ✅ |
| New struct field | No | Yes (`had_mark_revert`) |
| Complexity | Higher | Lower |

**Recommendation**: Merge PR #73 instead of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)