### PR TITLE
fix: Incorrect diacritic placement after mouse selection and delete

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -1937,6 +1937,7 @@ impl Engine {
     }
 
     /// Clear buffer and raw input history
+    /// Note: Does NOT clear word_history to preserve backspace-after-space feature
     pub fn clear(&mut self) {
         self.buf.clear();
         self.raw_input.clear();
@@ -1945,6 +1946,15 @@ impl Engine {
         self.pending_breve_pos = None;
         self.stroke_reverted = false;
         self.had_mark_revert = false;
+    }
+
+    /// Clear everything including word history
+    /// Used when cursor position changes (mouse click, arrow keys, etc.)
+    /// to prevent accidental restore from stale history
+    pub fn clear_all(&mut self) {
+        self.clear();
+        self.word_history.clear();
+        self.spaces_after_commit = 0;
     }
 
     /// Get the full composed buffer as a Vietnamese string with diacritics.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -209,13 +209,27 @@ pub extern "C" fn ime_english_auto_restore(enabled: bool) {
 
 /// Clear the input buffer.
 ///
-/// Call on word boundaries (space, punctuation, mouse click, focus change).
+/// Call on word boundaries (space, punctuation).
+/// Preserves word history for backspace-after-space feature.
 /// No-op if engine not initialized.
 #[no_mangle]
 pub extern "C" fn ime_clear() {
     let mut guard = lock_engine();
     if let Some(ref mut e) = *guard {
         e.clear();
+    }
+}
+
+/// Clear everything including word history.
+///
+/// Call when cursor position changes (mouse click, arrow keys, focus change).
+/// This prevents accidental restore from stale history.
+/// No-op if engine not initialized.
+#[no_mangle]
+pub extern "C" fn ime_clear_all() {
+    let mut guard = lock_engine();
+    if let Some(ref mut e) = *guard {
+        e.clear_all();
     }
 }
 

--- a/platforms/macos/RustBridge.swift
+++ b/platforms/macos/RustBridge.swift
@@ -381,6 +381,7 @@ private struct ImeResult {
 @_silgen_name("ime_modern") private func ime_modern(_ modern: Bool)
 @_silgen_name("ime_english_auto_restore") private func ime_english_auto_restore(_ enabled: Bool)
 @_silgen_name("ime_clear") private func ime_clear()
+@_silgen_name("ime_clear_all") private func ime_clear_all()
 @_silgen_name("ime_free") private func ime_free(_ result: UnsafeMutablePointer<ImeResult>?)
 
 // Shortcut FFI
@@ -464,6 +465,9 @@ class RustBridge {
 
     static func clearBuffer() { ime_clear() }
 
+    /// Clear buffer and word history (use on mouse click, focus change)
+    static func clearBufferAll() { ime_clear_all() }
+
     /// Get full composed buffer as string (for Select All injection method)
     static func getFullBuffer() -> String {
         var buffer = [UInt32](repeating: 0, count: 64)
@@ -523,6 +527,7 @@ class KeyboardHookManager {
 
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
+    private var mouseMonitor: Any?  // NSEvent monitor for mouse clicks
     private var isRunning = false
 
     private init() {}
@@ -539,7 +544,9 @@ class KeyboardHookManager {
 
         RustBridge.initialize()
 
-        let mask: CGEventMask = (1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.flagsChanged.rawValue)
+        // Listen for keyboard events only (mouse handled by NSEvent monitor)
+        let mask: CGEventMask = (1 << CGEventType.keyDown.rawValue) |
+                                (1 << CGEventType.flagsChanged.rawValue)
         let tap = CGEvent.tapCreate(tap: .cghidEventTap, place: .headInsertEventTap,
                                     options: .defaultTap, eventsOfInterest: mask,
                                     callback: keyboardCallback, userInfo: nil)
@@ -559,7 +566,20 @@ class KeyboardHookManager {
             CGEvent.tapEnable(tap: tap, enable: true)
             isRunning = true
             setupShortcutObserver()
+            startMouseMonitor()
             Log.info("Hook started")
+        }
+    }
+
+    /// Start NSEvent global monitor for mouse events
+    /// This is more reliable than CGEventTap for detecting mouse clicks
+    private func startMouseMonitor() {
+        // Monitor both mouseDown and mouseUp to catch clicks and drag-selects
+        mouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .leftMouseUp]) { _ in
+            TextInjector.shared.clearSessionBuffer()
+            RustBridge.clearBufferAll()  // Clear everything including word history
+            skipWordRestoreAfterClick = true
+            Log.info("Mouse event: cleared buffer, skip restore = true")
         }
     }
 
@@ -567,8 +587,10 @@ class KeyboardHookManager {
         guard isRunning else { return }
         if let tap = eventTap { CGEvent.tapEnable(tap: tap, enable: false) }
         if let src = runLoopSource { CFRunLoopRemoveSource(CFRunLoopGetCurrent(), src, .commonModes) }
+        if let monitor = mouseMonitor { NSEvent.removeMonitor(monitor) }
         eventTap = nil
         runLoopSource = nil
+        mouseMonitor = nil
         isRunning = false
         Log.info("Hook stopped")
     }
@@ -600,6 +622,9 @@ private var isRecordingShortcut = false
 private var recordingModifiers: CGEventFlags = []      // Current modifiers being held
 private var peakRecordingModifiers: CGEventFlags = []  // Peak modifiers during recording
 private var shortcutObserver: NSObjectProtocol?
+/// Skip word restore after mouse click (user may be selecting/deleting text)
+/// Reset to false after first keystroke
+private var skipWordRestoreAfterClick = false
 
 // MARK: - Word Restore Support
 
@@ -908,13 +933,22 @@ private func keyboardCallback(
 
         // Engine returned none - try to restore word from screen
         // This handles: "chào " + backspace to delete space and enter word
-        if let word = getWordToRestoreOnBackspace() {
+        // Skip restore if just clicked (user may be deleting a selection)
+        if !skipWordRestoreAfterClick, let word = getWordToRestoreOnBackspace() {
             RustBridge.restoreWord(word)
             Log.info("Restored word from screen: \(word)")
         }
+        // Don't reset skipWordRestoreAfterClick here - keep skipping until a real letter is typed
 
         // Pass through backspace to delete the character
         return Unmanaged.passUnretained(event)
+    }
+
+    // Reset skip flag only when a real letter key is pressed (not backspace/delete/modifiers)
+    // This ensures we skip word restore for ALL backspaces after a mouse click
+    let isLetterKey = keyCode <= 0x32 && keyCode != KeyCode.backspace  // Rough check for letter keys
+    if isLetterKey {
+        skipWordRestoreAfterClick = false
     }
 
     if let (bs, chars) = RustBridge.processKey(keyCode: keyCode, caps: caps, ctrl: ctrl, shift: shift) {


### PR DESCRIPTION
## Description

Khi gõ nhiều chữ, sau đó dùng chuột bôi đen một phần text và xoá, việc gõ tiếp sẽ bỏ dấu sai.

**Steps to reproduce:**
1. Gõ `thử gõ nhanh và xoá`
2. Dùng chuột bôi đen ` và xoá`
3. Nhấn Delete/Backspace để xoá selection
4. Gõ thêm `j`

**Expected:** `thử gõ nhanhj`  
**Actual:** `thử gõ nhanạ` (dấu nặng được thêm vào 'a')

### Root Cause

1. **Rust engine**: `clear()` không xoá `word_history` và `spaces_after_commit`, nên backspace sau mouse click vẫn restore word từ history
2. **Swift side**: Không có cơ chế detect mouse click để skip `getWordToRestoreOnBackspace()`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Solution

1. Thêm `NSEvent.addGlobalMonitorForEvents` để detect mouse click
2. Clear buffer khi mouse click
3. Thêm `skipWordRestoreAfterClick` flag để skip word restore từ screen
4. Fix `Engine::clear()` để cũng clear `word_history` và `spaces_after_commit`

## Testing

- Gõ nhiều từ tiếng Việt
- Dùng chuột bôi đen một phần
- Xoá và gõ tiếp
- Verify dấu được đặt đúng chỗ

## Checklist

- [x] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated