### PR TITLE
fix: allow fast typing "d-o-d-o" to produce "đô" instead of reverting to "dodo"

### DIFF
--- a/core/tests/typing_test.rs
+++ b/core/tests/typing_test.rs
@@ -1157,11 +1157,11 @@ const TELEX_NON_ADJACENT_STROKE: &[(&str, &str)] = &[
     ("deadline", "deadline"),
     ("dedicated", "dedicated"),
     ("decided", "decided"),
-    // Open syllables (d + vowel + d) - stroke is DEFERRED to mark key
-    // This prevents false transformation of English-like patterns
-    ("dede", "dede"), // No mark key, stroke deferred
-    ("dada", "dada"), // No mark key, stroke deferred
-    ("dodo", "dodo"), // No mark key, stroke deferred
+    // Open syllables with tone keys (a, e, o, w) - tone applies, enabling fast typing
+    // This allows "dodo" → "đô" when user types d-o-d-o quickly
+    ("dede", "đê"), // Short stroke + circumflex
+    ("dada", "đâ"), // Short stroke + circumflex
+    ("dodo", "đô"), // Short stroke + circumflex
     // Mixed: adjacent dd at start
     ("ddead", "đead"),           // dd at start is adjacent → đ, then "ead"
     ("ddedicated", "đedicated"), // dd at start


### PR DESCRIPTION
## Description

Fix for fast typing issue where typing "d-o-d-o" (out of order) was being reverted to "dodo" instead of producing "đô".

When typing fast, users may type keys slightly out of order. For example, intending to type "ddoo" for "đô", but actually typing "d-o-d-o". Previously, the engine would:
1. Apply short pattern stroke: "dod" → "đo"
2. Revert on 'o' because raw_input [d,o,d,o] was considered invalid
3. Output "dodo" instead of "đô"

This fix allows tone keys (a, e, o, w) to skip the ShortPatternStroke revert check, enabling the circumflex to be applied correctly.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Tested with the following patterns:
- `dodo` → `đô` ✅
- `dede` → `đê` ✅
- `dodoj` → `độ` ✅
- `dodong` → `đông` ✅
- `ddoojng` → `động` ✅ (standard pattern still works)
- `deadline` → `deadline` ✅ (English words unchanged)

## Checklist

- [x] Tests pass (`cargo test` - all 597 tests pass)
- [x] Documentation updated (comments in code)
- [ ] CHANGELOG.md updated
