### PR TITLE
fix: Short-pattern stroke revert not working (dadd → dadd instead of dad)

### DIFF
--- a/core/tests/engine_test.rs
+++ b/core/tests/engine_test.rs
@@ -331,6 +331,18 @@ fn stroke_delayed_valid_vietnamese() {
 }
 
 #[test]
+fn stroke_short_pattern_revert() {
+    // When short-pattern stroke is applied (dad → đa), another 'd' reverts it (dadd → dad)
+    // Similar to ddd → dd behavior for adjacent stroke
+    telex(&[
+        ("dadd", "dad"), // Short-pattern stroke reverted
+        ("didd", "did"), // Short-pattern stroke reverted
+        ("dodd", "dod"), // Short-pattern stroke reverted
+        ("dudd", "dud"), // Short-pattern stroke reverted
+    ]);
+}
+
+#[test]
 fn stroke_in_word() {
     telex(&[
         ("ddas", "đá"),


### PR DESCRIPTION
## Description

Khi gõ `dadd`, kết quả là `dadd` thay vì `dad` như mong đợi.

### Hành vi hiện tại
- `dad` → `đa` ✓ (short-pattern stroke hoạt động)
- `dadd` → `dadd` ✗ (không revert stroke)

### Hành vi mong đợi
- `dad` → `đa` (short-pattern stroke)
- `dadd` → `dad` (revert stroke, tương tự `ddd` → `dd`)

## Root Cause

Khi short-pattern stroke được áp dụng (`dad` → `đa`), gõ thêm `d`:
1. Logic revert ở `process()` line 475-497 được thiết kế cho non-stroke keys (như `i` trong `dedi`)
2. Với stroke key (`d`), logic này rebuild buffer từ `raw_input` → `dadd`
3. `try_stroke()` không được gọi vì logic trước đó đã return

## Solution

1. Thêm `!is_stroke_key` vào điều kiện revert ShortPatternStroke trong `process()`
2. Thêm xử lý revert ShortPatternStroke trong `try_stroke()` (tương tự `Transform::Stroke`)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

```bash
cargo test stroke_short_pattern_revert