### PR TITLE
fix: Mark incorrectly repositioned when typing extra vowels after diphthong

### DIFF
--- a/core/tests/bug_reports_test.rs
+++ b/core/tests/bug_reports_test.rs
@@ -188,3 +188,28 @@ fn bug7_backspace_resets_stroke_reverted() {
     );
     assert_eq!(result, "đ", "After backspace, dd should produce đ again");
 }
+
+// =============================================================================
+// BUG 8: "taifii" -> "taìi", expected "tàii"
+// When extra vowels are typed after a valid diphthong with mark, the mark
+// should stay on the correct vowel for the original diphthong, not move to
+// a new position based on invalid triphthong rules.
+// =============================================================================
+
+#[test]
+fn bug8_extra_vowel_after_diphthong_mark() {
+    let mut e = Engine::new();
+    // taif → tài (mark on 'a' for "ai" diphthong)
+    // taifi → should be tàii (mark stays on 'a', not moved to 'i')
+    // The issue was: typing "taifi" produced "taìi" (mark wrongly on first 'i')
+    // Fixed: "taifi" now correctly produces "tàii" (mark stays on 'a')
+    let result = type_word(&mut e, "taifi");
+    println!("'taifi' -> '{}' (expected: 'tàii')", result);
+    assert_eq!(result, "tàii", "'taifi' should produce 'tàii' (mark on 'a')");
+
+    // Also verify the 6-key input produces 3 i's
+    let mut e2 = Engine::new();
+    let result2 = type_word(&mut e2, "taifii");
+    println!("'taifii' -> '{}' (expected: 'tàiii')", result2);
+    assert_eq!(result2, "tàiii", "'taifii' should produce 'tàiii' (mark on 'a')");
+}


### PR DESCRIPTION
## Description

When typing extra vowels after a diphthong that already has a tone mark, the mark is incorrectly repositioned.

**Example:**

- Input: `taifii`
- Current result: `taìi` (huyền mark on 'i')
- Expected result: `tàii` (huyền mark stays on 'a')

## Root Cause

In `vowel.rs`, the `find_triphthong_position` function defaults to placing the mark on the middle vowel when no pattern is found in `TRIPHTHONG_PATTERNS`. This causes incorrect behavior when user types extra vowels after a valid diphthong like "ai".

With "tài" + "i":

- Vowels: [a, i, i] (3 vowels)
- "aii" is not a valid triphthong
- Default: middle vowel → mark moves from 'a' to first 'i' → "taìi"

## Solution

1. **`find_triphthong_position`**: When no triphthong pattern matches, fallback to diphthong rules for the first 2 vowels.

   - "aii" → check "ai" → `TONE_FIRST_PATTERNS` → mark on first vowel (a)

2. **`find_default_position`**: Apply same logic for 4+ vowels.

3. **`find_tone_position`**: Special handling for `gi-initial` - when gi-initial is detected and first vowel is 'i', skip it since 'i' is part of the "gi" consonant.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update

## Testing

```bash
cd core && cargo test
```

- ✅ 545 tests pass (including fixed `edge_gi_with_mark`)
- ✅ Added new test `bug8_extra_vowel_after_diphthong_mark`

**Test cases:**
| Input | Before | After |
|-------|--------|-------|
| `taifi` | `taìi` | `tàii` ✅ |
| `taifii` | `taìii` | `tàiii` ✅ |
| `giauf` | `gìau` | `giàu` ✅ |

## Files Changed

- `core/src/data/vowel.rs` - Fix tone position logic
- `core/tests/bug_reports_test.rs` - Add regression test

## Checklist

- [x] Tests pass (`cargo test`)
- [x] No clippy warnings
- [x] Regression test added
- [ ] CHANGELOG.md updated
