### PR TITLE
fix(engine): auto-restore không hoạt động đúng với vần ơ và ư (ow, uw patterns)

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -3174,14 +3174,16 @@ impl Engine {
         // Pattern 5: W at end after vowel → English (like "raw", "law", "saw", "view")
         // W as final is not valid Vietnamese, it's an English pattern
         // Exception: "uw" ending is Vietnamese (tuw → tư)
+        // Exception: "ow" ending is Vietnamese (cow → cơ)
         // Exception: W modified a diphthong (oiw → ơi where OI is diphthong, W adds horn to O)
         if self.raw_input.len() >= 2 {
             let (last, _, _) = self.raw_input[self.raw_input.len() - 1];
             if last == keys::W {
                 let (second_last, _, _) = self.raw_input[self.raw_input.len() - 2];
-                // W after vowel (not U) at end is English: raw, law, saw
+                // W after vowel (not U or O) at end is English: raw, law, saw
                 // W after U is Vietnamese: tuw → tư
-                if keys::is_vowel(second_last) && second_last != keys::U {
+                // W after O is Vietnamese: cow → cơ
+                if keys::is_vowel(second_last) && second_last != keys::U && second_last != keys::O {
                     // Check if W was absorbed (modified existing vowel vs created new ư)
                     // "oiw" → "ơi": 3 chars → 2 chars (absorbed)
                     // "view" → "vieư": 4 chars → 4 chars (not absorbed)

--- a/core/tests/auto_restore_dynamic_test.rs
+++ b/core/tests/auto_restore_dynamic_test.rs
@@ -741,17 +741,19 @@ const W_FINAL_WORDS: &[(&str, &str)] = &[
     ("stew ", "stew "),
     ("threw ", "threw "),
     ("view ", "view "),
-    // -ow pattern (when pronounced /aʊ/)
-    ("bow ", "bow "),
-    ("brow ", "brow "),
-    ("cow ", "cow "),
-    ("how ", "how "),
-    ("now ", "now "),
-    ("plow ", "plow "),
-    ("row ", "row "),
-    ("sow ", "sow "),
-    ("vow ", "vow "),
-    ("wow ", "wow "),
+    // -ow pattern: single valid consonant + ow → cơ (Vietnamese ơ vowel)
+    // These form valid Vietnamese syllables (consonant + ơ)
+    ("bow ", "bơ "), // bơ = butter
+    ("cow ", "cơ "), // cơ = muscle/rice
+    ("how ", "hơ "), // hơ = to warm by fire
+    ("now ", "nơ "), // nơ = bow/ribbon
+    ("row ", "rơ "), // rơ = to fall/drop
+    ("sow ", "sơ "), // sơ = initial/raw
+    ("vow ", "vơ "), // vơ = to grab/gather
+    // -ow pattern: invalid initials → restore to English
+    ("brow ", "brow "), // br is invalid initial
+    ("plow ", "plow "), // pl is invalid initial
+    ("wow ", "wow "),   // w is invalid initial (handled by Pattern 1)
 ];
 
 #[test]


### PR DESCRIPTION
## Description

Ở chế độ tự khôi phục (auto-restore), gõ `cow ` trả về `cow ` thay vì `cơ `. Tương tự với các từ có vần ơ và ư.

**Nguyên nhân:** Logic Pattern 5 trong `has_english_modifier_pattern` đang coi tất cả pattern "nguyên âm + W ở cuối" là tiếng Anh, chỉ ngoại trừ U+W (uw → ư). Điều này khiến O+W bị nhận nhầm là tiếng Anh mặc dù "ơ" là nguyên âm tiếng Việt hợp lệ.

**Giải pháp:** Thêm ngoại lệ cho O+W pattern tương tự U+W.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Các test case cần verify:

| Input   | Expected | Mô tả                                   |
| ------- | -------- | --------------------------------------- |
| `cow `  | `cơ `    | cơ = cơm/cơ bắp                         |
| `bow `  | `bơ `    | bơ = bơ (butter)                        |
| `how `  | `hơ `    | hơ = hơ lửa                             |
| `now `  | `nơ `    | nơ = nơ (ribbon)                        |
| `row `  | `rơ `    | rơ = rơi                                |
| `sow `  | `sơ `    | sơ = sơ khai                            |
| `vow `  | `vơ `    | vơ = vơ vét                             |
| `brow ` | `brow `  | br là phụ âm đầu không hợp lệ → restore |
| `plow ` | `plow `  | pl là phụ âm đầu không hợp lệ → restore |
| `wow `  | `wow `   | w là phụ âm đầu không hợp lệ → restore  |

### Chạy test:

```bash
cd core
cargo test w_final -- --nocapture
cargo test  # Run all tests
```

## Checklist

- [ ] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated

## Files to modify

1. `core/src/engine/mod.rs` - Pattern 5 trong `has_english_modifier_pattern`
2. `core/tests/auto_restore_dynamic_test.rs` - Cập nhật expected values cho -ow pattern
