### PR TITLE
fix(engine): fix auto-restore not triggering on space for system

### DIFF
--- a/core/tests/auto_restore_dynamic_test.rs
+++ b/core/tests/auto_restore_dynamic_test.rs
@@ -560,6 +560,10 @@ const MODIFIER_CONSONANT_WORDS: &[(&str, &str)] = &[
     ("next ", "next "),
     ("text ", "text "),
     ("textbook ", "textbook "),
+    // s modifier + consonant + vowel patterns
+    ("system ", "system "),
+    ("systemic ", "systemic "),
+    ("syntax ", "syntax "),
 ];
 
 #[test]


### PR DESCRIPTION

## Mô tả
Các từ như "system" không được restore khi bật tính năng "Tự khôi phục từ tiếng Anh".
Mình test vài ngày thì chưa gặp trường hợp bị restore sai với tiếng Việt.

## Loại thay đổi
- [x] Enhancement
- [ ] ✨ Tính năng mới
- [ ] 📝 Tài liệu
- [ ] ♻️ Refactor

## Checklist
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Không có clippy warnings
