### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@
 
 ## 📥 Tải về & Cài đặt
 
+[![Run in Smithery](https://smithery.ai/badge/skills/khaphanspace)](https://smithery.ai/skills?ns=khaphanspace&utm_source=github&utm_medium=badge)
+
+
 ### 🍺 Homebrew (macOS - Khuyến nghị)
 
 ```bash


### PR DESCRIPTION
## Add skill discoverability badge

Your 1 Claude skill is already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/khaphanspace)](https://smithery.ai/skills?ns=khaphanspace&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.