### PR TITLE
fix(engine): preserve C+W+A pattern as Vietnamese in auto-restore (#151)

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -3816,6 +3816,14 @@ impl Engine {
                                 }
                             }
 
+                            // Issue #151: C+W+A pattern is Vietnamese "ưa" (mưa, cưa, lưa, etc.)
+                            // Pattern: consonant + W + A → valid Vietnamese diphthong
+                            // When raw_input is exactly 3 chars (C+W+A), this is Vietnamese
+                            // Examples: mwa → mưa, cwa → cưa, lwa → lưa, twa → tưa
+                            if third == keys::A && self.raw_input.len() == 3 {
+                                return false;
+                            }
+
                             // Check if there's ANY tone modifier (j/s/f/r/x) in the rest of the word
                             let tone_modifiers = [keys::S, keys::F, keys::R, keys::X, keys::J];
                             let has_tone_modifier = self.raw_input[2..]

--- a/core/tests/english_auto_restore_test.rs
+++ b/core/tests/english_auto_restore_test.rs
@@ -828,3 +828,35 @@ fn vowel_triggered_circumflex_stays_vietnamese() {
         ("papa ", "papa "), // p+a+p+a → pâp (no mark, restore to English)
     ]);
 }
+
+// =============================================================================
+// ISSUE #151 - "mưa" (rain) should NOT be auto-restored
+// Vietnamese word with horn on 'u' pattern
+// =============================================================================
+
+#[test]
+fn issue151_mua_horn_not_restored() {
+    // "mưa" (rain) is a common Vietnamese word - should NOT be auto-restored
+    // Pattern: m + u + w(horn on u) + a → mưa
+    // Or: m + u + a + w(horn on u) → mưa
+    telex_auto_restore(&[
+        ("muwa ", "mưa "), // m + u + w + a → mưa (NOT "mwa")
+        ("muaw ", "mưa "), // m + u + a + w → mưa (NOT "mwa")
+        ("mwa ", "mưa "),  // Issue #151: shorthand m + w + a → mưa (NOT "mwa")
+        // Similar patterns with other initials
+        ("chuwa ", "chưa "), // chưa (not yet)
+        ("chuaw ", "chưa "), // chưa (alternative typing)
+        ("cwa ", "cưa "),    // Issue #151: shorthand c + w + a → cưa
+        ("thuwa ", "thưa "), // thưa (dear/sparse)
+        ("thuaw ", "thưa "), // thưa (alternative)
+        ("luwa ", "lưa "),   // lưa (somewhat valid pattern)
+        ("luaw ", "lưa "),   // lưa (alternative)
+        ("lwa ", "lưa "),    // Issue #151: shorthand l + w + a → lưa
+        // With marks (tones)
+        ("muwas ", "mứa "), // mứa (sắc)
+        ("muwaf ", "mừa "), // mừa (huyền)
+        ("muwar ", "mửa "), // mửa (hỏi) - vomit
+        ("muwax ", "mữa "), // mữa (ngã)
+        ("muwaj ", "mựa "), // mựa (nặng)
+    ]);
+}


### PR DESCRIPTION
## Description

Khi gõ chữ "mưa" bằng shorthand Telex (`mwa`) rồi bấm dấu cách, chế độ tự động khôi phục từ sai (auto-restore) nhầm tưởng đây là từ tiếng Anh và khôi phục thành "mwa" thay vì giữ "mưa".

### Steps to reproduce

1. Bật chế độ "Tự động khôi phục từ sai" (English auto-restore)
2. Gõ `mwa` (shorthand cho "mưa")
3. Bấm dấu cách
4. Kết quả: `mwa ` (sai) thay vì `mưa ` (đúng)

### Expected behavior

- `mwa ` → `mưa ` (giữ nguyên tiếng Việt)
- `cwa ` → `cưa `
- `lwa ` → `lưa `

### Actual behavior

- `mwa ` → `mwa ` (bị khôi phục thành tiếng Anh)

## Root Cause

Logic trong hàm `has_english_modifier_pattern()` (file `core/src/engine/mod.rs`) phát hiện pattern "consonant + W + vowel without tone modifier" và coi đây là tiếng Anh (như "swim").

Tuy nhiên, pattern "C + W + A" (như `mwa`, `cwa`, `lwa`) thực ra là tiếng Việt hợp lệ cho âm "ưa" (mưa, cưa, lưa).

## Fix

Thêm exception cho pattern "C + W + A" khi `raw_input.len() == 3`:

```rust
// Issue #151: C+W+A pattern is Vietnamese "ưa" (mưa, cưa, lưa, etc.)
// Pattern: consonant + W + A → valid Vietnamese diphthong
// When raw_input is exactly 3 chars (C+W+A), this is Vietnamese
// Examples: mwa → mưa, cwa → cưa, lwa → lưa, twa → tưa
if third == keys::A && self.raw_input.len() == 3 {
    return false;
}
```

## Files Changed

- `core/src/engine/mod.rs` - Thêm exception cho pattern C+W+A
- `core/tests/english_auto_restore_test.rs` - Thêm test cases cho issue #151

## Test Cases

```rust
#[test]
fn issue151_mua_horn_not_restored() {
    telex_auto_restore(&[
        ("mwa ", "mưa "),  // Issue #151: shorthand m + w + a → mưa
        ("cwa ", "cưa "),  // Issue #151: shorthand c + w + a → cưa
        ("lwa ", "lưa "),  // Issue #151: shorthand l + w + a → lưa
        // Full typing patterns still work
        ("muwa ", "mưa "),
        ("muaw ", "mưa "),
    ]);
}
```

## Checklist

- [x] Tests pass (`cargo test`)
- [x] No clippy warnings
- [x] Code formatted (`cargo fmt`)
- [x] Test cases added for the fix
