### PR TITLE
fix(linux): use forwardKey for backspace instead of deleteSurrounding…

### DIFF
--- a/platforms/linux/CMakeLists.txt
+++ b/platforms/linux/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(fcitx5-gonhanh VERSION 1.0.0 LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+# Fcitx5 required C++ 20
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find Fcitx5 (Ubuntu package names: Fcitx5Core, Fcitx5Module)

--- a/platforms/linux/src/RustBridge.cpp
+++ b/platforms/linux/src/RustBridge.cpp
@@ -31,7 +31,7 @@ std::pair<int, std::string> RustBridge::processKey(
         output.first = result->backspace;
 
         // Convert UTF-32 chars to UTF-8 string
-        for (uint8_t i = 0; i < result->count && i < 32; ++i) {
+        for (size_t i = 0; i < result->count && i < 256; ++i) {
             if (result->chars[i] > 0) {
                 output.second += codePointToUtf8(result->chars[i]);
             }

--- a/platforms/linux/src/RustBridge.h
+++ b/platforms/linux/src/RustBridge.h
@@ -8,26 +8,26 @@
 // FFI Result structure - must match core/src/engine/mod.rs
 // #[repr(C)]
 // pub struct Result {
-//     pub chars: [u32; 32],
+//     pub chars: [u32; MAX],  // MAX = 256 from buffer.rs
 //     pub action: u8,
 //     pub backspace: u8,
 //     pub count: u8,
-//     pub _pad: u8,
+//     pub flags: u8,
 // }
 //
 // Note: Rust #[repr(C)] uses C ABI layout, which matches C++ struct layout
-// for this specific arrangement. The array (128 bytes) is followed by
-// 4 bytes of u8 fields = 132 bytes total with no implicit padding needed.
+// for this specific arrangement. The array (1024 bytes) is followed by
+// 4 bytes of u8 fields = 1028 bytes total with no implicit padding needed.
 struct ImeResult {
-    uint32_t chars[32];  // 128 bytes
+    uint32_t chars[256]; // 1024 bytes (must match Rust MAX constant)
     uint8_t action;      // 1 byte
     uint8_t backspace;   // 1 byte
     uint8_t count;       // 1 byte
-    uint8_t _pad;        // 1 byte (explicit padding to 4-byte boundary)
+    uint8_t flags;       // 1 byte (flags: bit 0 = key_consumed)
 };
 
 // Verify struct size matches Rust at compile time
-static_assert(sizeof(ImeResult) == 132, "ImeResult size mismatch with Rust core");
+static_assert(sizeof(ImeResult) == 1028, "ImeResult size mismatch with Rust core");
 
 // Action types
 enum class ImeAction : uint8_t {


### PR DESCRIPTION
## Mô tả
Fix lỗi gõ tiếng Việt trong terminal (XIM protocol). Khi gõ "vieetj" bị ra "vieêệt" thay vì "việt" do deleteSurroundingText không work với XIM.

- deleteSurroundingText doesn't work with XIM protocol (terminals)
    - Cách này gây syscalls hơn - nếu backspace=3, gọi 3 lần thay vì 1
- Use forwardKey(BackSpace) for reliable character deletion
- Update ImeResult struct size to match Rust core (256 chars)
    - Rust core sử dụng MAX = 256. Không thể revert về 32 vì sẽ gây buffer overflow và undefined behavior - Rust gửi 256 chars nhưng C++ chỉ đọc 32. 
- Upgrade to C++20 for fcitx5 compatibility

## Loại thay đổi
- [x] 🐛 Sửa lỗi
- [ ] ✨ Tính năng mới
- [ ] 📝 Tài liệu
- [ ] ♻️ Refactor

## Checklist
- [x] Tests pass (`cargo test`)
- [x] Code formatted (`cargo fmt`)
- [x] Không có clippy warnings
