### PR TITLE
fix(engine): shortcut works after delete all and retype (#212)

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -877,6 +877,13 @@ impl Engine {
             self.restored_pending_clear = false;
         }
 
+        // Issue #212: Reset has_non_letter_prefix when user starts typing letter into empty buffer
+        // This allows shortcuts to work after: expand → delete all → retype
+        // e.g., "ko" → "không " → backspace×6 → "ko" → should expand again
+        if self.buf.is_empty() && keys::is_letter(key) && self.has_non_letter_prefix {
+            self.has_non_letter_prefix = false;
+        }
+
         // Auto-capitalize: force uppercase for first letter after sentence-ending punctuation
         let was_auto_capitalized = self.pending_capitalize && keys::is_letter(key) && !caps;
         let effective_caps = if self.pending_capitalize && keys::is_letter(key) {


### PR DESCRIPTION
## Summary
- Reset `has_non_letter_prefix` flag when user starts typing letter into empty buffer
- Previously, backspacing past buffer caused flag to stick, blocking shortcuts on subsequent words

## Test plan
- [x] `shortcut_works_after_delete_all_and_retype` - pass
- [x] `shortcut_works_after_partial_delete_and_retype` - pass
- [x] `shortcut_works_multiple_delete_retype_cycles` - pass
- [x] All 843+ existing tests pass

Closes #212