### PR TITLE
fix(macos): debug log not working when file created after app startup

### DIFF
--- a/platforms/macos/RustBridge.swift
+++ b/platforms/macos/RustBridge.swift
@@ -1491,6 +1491,7 @@ class PerAppModeManager {
         guard bundleId != currentBundleId else { return }
         currentBundleId = bundleId
 
+        Log.refresh()  // Re-check debug log file existence on app switch
         RustBridge.clearBuffer()
         TextInjector.shared.clearSessionBuffer()
         clearDetectionCache()  // Clear injection method cache on app switch


### PR DESCRIPTION
## Description

Debug logging không hoạt động khi user tạo file `/tmp/gonhanh_debug.log` sau khi app đã khởi động.

## Steps to Reproduce

1. Khởi động Gõ Nhanh (không có file debug log)
2. Chạy: `touch /tmp/gonhanh_debug.log && tail -f /tmp/gonhanh_debug.log`
3. Gõ tiếng Việt trong bất kỳ app nào
4. **Expected:** Log xuất hiện trong terminal
5. **Actual:** Không có log nào

## Root Cause

`Log.isEnabled` được cache lần đầu tiên khi app khởi động. Nếu file không tồn tại lúc đó, `_enabled = false` và không bao giờ được refresh lại dù user tạo file sau đó.

`Log.refresh()` tồn tại nhưng không được gọi ở đâu cả.

## Solution

Gọi `Log.refresh()` trong `handleAppSwitch()` để re-check file existence khi user switch app.
