### PR TITLE
fix(macos): per-app mode fails to restore state for apps explicitly set to ON

### DIFF
--- a/platforms/macos/MainSettingsView.swift
+++ b/platforms/macos/MainSettingsView.swift
@@ -309,7 +309,7 @@ class AppState: ObservableObject {
 
     func savePerAppMode(bundleId: String, enabled: Bool) {
         var modes = UserDefaults.standard.dictionary(forKey: SettingsKey.perAppModes) as? [String: Bool] ?? [:]
-        if enabled { modes.removeValue(forKey: bundleId) } else { modes[bundleId] = false }
+        modes[bundleId] = enabled  // Store both ON and OFF so hasPerAppMode works correctly
         UserDefaults.standard.set(modes, forKey: SettingsKey.perAppModes)
     }
 


### PR DESCRIPTION
# fix(macos): per-app mode fails to restore state for apps explicitly set to ON

## Description

Per-app mode fails to restore the correct state for apps that user has explicitly set to ON.

## Bug Details

In commit `9a0135a`, the `hasPerAppMode` function checks `modes[bundleId] != nil`, but `savePerAppMode` **removes the entry** when app is set to ON:

```swift
if enabled { modes.removeValue(forKey: bundleId) } else { modes[bundleId] = false }
```

**Result:** Apps set to ON are treated as "first-time apps" → inherit state from previous app instead of restoring to ON.

## Steps to Reproduce

1. Enable per-app mode
2. Set Safari = ON, Chrome = OFF
3. Switch from Safari → Chrome (state becomes OFF)
4. Switch back to Safari → Safari stays OFF (wrong, should be ON)

## Expected Behavior

Safari should restore to ON state since user explicitly configured it.

## Fix

Store both ON and OFF states in dictionary:

```swift
modes[bundleId] = enabled  // Store both ON and OFF so hasPerAppMode works correctly
```

## Type of Change

- [x] Bug fix

## Testing

1. Enable per-app mode
2. Configure multiple apps with different states (some ON, some OFF)
3. Switch between apps
4. Verify each app restores to its configured state

## Checklist

- [x] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated
