### PR TITLE
fix(engine): horn modifier incorrectly applied to 'u' in "Qu-" initial pattern

### DIFF
--- a/core/src/data/vowel.rs
+++ b/core/src/data/vowel.rs
@@ -551,18 +551,28 @@ impl Phonology {
                     if k1 == pattern.v1 && k2 == pattern.v2 {
                         match pattern.placement {
                             HornPlacement::Both => {
-                                // Issue #133: Check if "uo" pattern is at end of syllable (no final)
-                                // If no final consonant/vowel after "uo", only apply horn to 'o'
-                                // Examples: "huow" → "huơ", "khuow" → "khuơ"
-                                // But: "duowc" → "dược", "muowif" → "mười" (both get horn)
-                                let has_final = buffer_keys.get(pos2 + 1).is_some();
-                                if k1 == keys::U && k2 == keys::O && !has_final {
-                                    // "uơ" pattern - only 'o' gets horn
+                                // Check if 'u' is preceded by 'Q' (qu-initial consonant cluster)
+                                // In "Qu-", the 'u' is part of the initial and should not get horn
+                                // Examples: "Quoiws" → "Quới" (not "Qưới"), "quốc" (not "qước")
+                                let preceded_by_q =
+                                    pos1 > 0 && buffer_keys.get(pos1 - 1).copied() == Some(keys::Q);
+                                if preceded_by_q {
+                                    // Only apply horn to the second vowel
                                     result.push(pos2);
                                 } else {
-                                    // "ươ" pattern - both get horn
-                                    result.push(pos1);
-                                    result.push(pos2);
+                                    // Issue #133: Check if "uo" pattern is at end of syllable (no final)
+                                    // If no final consonant/vowel after "uo", only apply horn to 'o'
+                                    // Examples: "huow" → "huơ", "khuow" → "khuơ"
+                                    // But: "duowc" → "dược", "muowif" → "mười" (both get horn)
+                                    let has_final = buffer_keys.get(pos2 + 1).is_some();
+                                    if k1 == keys::U && k2 == keys::O && !has_final {
+                                        // "uơ" pattern - only 'o' gets horn
+                                        result.push(pos2);
+                                    } else {
+                                        // "ươ" pattern - both get horn
+                                        result.push(pos1);
+                                        result.push(pos2);
+                                    }
                                 }
                             }
                             HornPlacement::First => {

--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -1493,7 +1493,17 @@ impl Engine {
                         let is_uo_pattern = c1.key == keys::U && c2.key == keys::O;
                         let has_final = self.buf.get(pos2 + 1).is_some();
 
-                        if is_uo_pattern && !has_final {
+                        // Check if 'u' is preceded by 'Q' (qu-initial consonant cluster)
+                        // In "Qu-", the 'u' is part of the initial and should not get horn
+                        // Examples: "Quoiws" → "Quới" (not "Qưới"), "quốc" (not "qước")
+                        let preceded_by_q =
+                            pos1 > 0 && self.buf.get(pos1 - 1).map(|c| c.key) == Some(keys::Q);
+
+                        if preceded_by_q {
+                            // "Qu-" pattern - only second vowel gets horn
+                            target_positions.push(pos2);
+                            self.pending_u_horn_pos = None;
+                        } else if is_uo_pattern && !has_final {
                             // "uơ" pattern - only 'o' gets horn initially
                             // Set pending so 'u' gets horn if final consonant/vowel is added
                             target_positions.push(pos2);

--- a/core/tests/typing_test.rs
+++ b/core/tests/typing_test.rs
@@ -1465,6 +1465,9 @@ const TELEX_HORN_PLACEMENT: &[(&str, &str)] = &[
     ("duowcj", "dược"), // dược - medicine (horn + nặng mark)
     ("muowif", "mười"), // mười - ten (horn + huyền mark on ờ)
     ("luowst", "lướt"), // lướt - to slide (final 't' triggers horn on 'u')
+    // "Qu-" initial pattern - 'u' is part of initial consonant, should NOT get horn
+    ("Quoiws", "Quới"), // Quới - name (NOT Qưới, 'u' is part of "Qu" initial)
+    ("quoocs", "quốc"), // quốc - country (NOT qướcc, 'u' is part of "Qu" initial)
 ];
 
 // ============================================================


### PR DESCRIPTION
## Description

Khi gõ "Quoiws" bằng Telex, kết quả là "Qưới" thay vì "Quới".

**Input:** `Quoiws`
**Expected:** `Quới`
**Actual:** `Qưới`

## Root Cause

Trong tiếng Việt, "Qu" là một phụ âm đầu (consonant cluster), trong đó 'u' là một phần của phụ âm, không phải nguyên âm. Khi áp dụng dấu móc ('w' trong Telex), không nên biến đổi 'u' trong pattern "Qu-".

## Affected Words

- Quới (tên người)
- quốc (country)
- Các từ khác bắt đầu bằng "Qu-" + nguyên âm "o"

## Solution

Thêm kiểm tra "Qu-" prefix trong logic áp dụng horn:
- `core/src/engine/mod.rs` - hàm xử lý compound horn
- `core/src/data/vowel.rs` - hàm `find_horn_positions()`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- Thêm test cases: `("Quoiws", "Quới")`, `("quoocs", "quốc")`
- Tất cả tests pass

## Checklist

- [x] Tests pass
- [x] Documentation updated (comments in code)
- [ ] CHANGELOG.md updated
