### PR TITLE
fix(engine): delayed circumflex incorrectly re-applied after revert when typing mark key

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -2308,10 +2308,12 @@ impl Engine {
                     // - Second vowel is at end (trigger position)
                     // - Has valid Vietnamese initial (skip English like "proposal")
                     // - No double initial (those work immediately without delay)
+                    // - User didn't just revert a circumflex (typing 3rd vowel to cancel)
                     if is_non_extending_final
                         && second_vowel_at_end
                         && has_valid_vietnamese_initial
                         && !has_vietnamese_double_initial
+                        && !self.had_circumflex_revert
                     {
                         // Skip delayed circumflex if raw_input is an English word
                         // This prevents "pasta" → "pất", "costa" → "côt", etc.

--- a/core/tests/engine_test.rs
+++ b/core/tests/engine_test.rs
@@ -771,6 +771,7 @@ fn delayed_circumflex_auto_restore_space() {
         ("toto ", "toto "),  // tôt (no mark) is NOT real VI → restore to English
         ("data ", "data "),  // dât (no mark) is NOT real VI → restore to English
         ("dataa ", "data "), // Revert: dataa → data (circumflex reverted)
+        ("dataas", "datas"), // Revert then mark: dataa → data, then 's' stays as letter
         ("noto ", "noto "),  // nôt (no mark) is NOT real VI → restore to English
         ("hete ", "hete "),  // hêt (no mark) is NOT real VI → restore to English
         ("tetee ", "tete "), // Revert: tetee → tete (circumflex reverted)


### PR DESCRIPTION
## Description

Typing "dataas" produces "dất" instead of expected "datas".

## Steps to Reproduce

1. Type "dataa" → correctly shows "data" (circumflex reverted)
2. Type "s" → incorrectly shows "dất" instead of "datas"

## Root Cause

When the user types the 3rd vowel to revert circumflex (dataa → data), the `had_circumflex_revert` flag is set. However, `try_mark` doesn't check this flag before re-applying delayed circumflex pattern.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- Added test case: `("dataas", "datas")`
- All existing delayed_circumflex tests pass

## Checklist

- [x] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated