### PR TITLE
fix(engine): standalone Đ incorrectly auto-restored to DD on break key (#247)

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -3833,8 +3833,11 @@ impl Engine {
 
                 // Simple logic: buffer invalid VN + raw in English dict → restore
                 // Special case: W at end + in dict → restore (foreign word pattern)
-                if has_stroke && !raw_in_english_dict {
-                    // Skip restore - Vietnamese abbreviation like đc, đt
+                // Issue #247: Standalone "đ" (buffer len 1 with stroke) should NOT restore
+                // This is intentional Vietnamese typing, not English "dd"
+                let is_standalone_stroke = self.buf.len() == 1 && has_stroke;
+                if has_stroke && (!raw_in_english_dict || is_standalone_stroke) {
+                    // Skip restore - Vietnamese abbreviation like đc, đt, or standalone đ
                 } else if w_at_end && raw_in_english_dict {
                     // W at end + in dict → restore foreign words (moscow, warsaw, saw)
                     return self.build_raw_chars_exact();

--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -3600,3 +3600,59 @@ fn shortcut_works_multiple_delete_retype_cycles() {
         }
     }
 }
+
+/// Issue #247: Standalone "Đ" should NOT be auto-restored to "DD" on break key
+/// When typing "DD" to get "Đ", pressing arrow key should keep "Đ", not revert to "DD"
+#[test]
+fn standalone_stroke_not_restored_on_break() {
+    // Test with arrow key (RIGHT)
+    let mut e = Engine::new();
+    e.set_method(0); // Telex
+    e.set_english_auto_restore(true);
+
+    // Type "DD" → should produce "Đ"
+    e.on_key(keys::D, true, false); // D (caps)
+    e.on_key(keys::D, true, false); // D (caps)
+
+    // Press RIGHT arrow (break key) - should NOT restore to "DD"
+    let r = e.on_key(keys::RIGHT, false, false);
+    assert_eq!(
+        r.action,
+        Action::None as u8,
+        "Standalone Đ should NOT be restored on arrow key"
+    );
+
+    // Test with space key
+    let mut e2 = Engine::new();
+    e2.set_method(0);
+    e2.set_english_auto_restore(true);
+
+    // Type "dd" → should produce "đ"
+    e2.on_key(keys::D, false, false);
+    e2.on_key(keys::D, false, false);
+
+    // Press SPACE - should NOT restore to "dd "
+    let r2 = e2.on_key(keys::SPACE, false, false);
+    assert_eq!(
+        r2.action,
+        Action::None as u8,
+        "Standalone đ should NOT be restored on space"
+    );
+
+    // Test with punctuation (DOT)
+    let mut e3 = Engine::new();
+    e3.set_method(0);
+    e3.set_english_auto_restore(true);
+
+    // Type "DD" → should produce "Đ"
+    e3.on_key(keys::D, true, false);
+    e3.on_key(keys::D, true, false);
+
+    // Press DOT (break key) - should NOT restore to "DD"
+    let r3 = e3.on_key(keys::DOT, false, false);
+    assert_eq!(
+        r3.action,
+        Action::None as u8,
+        "Standalone Đ should NOT be restored on punctuation"
+    );
+}


### PR DESCRIPTION
## Description

Fix standalone "Đ" being incorrectly auto-restored to "DD" when pressing break keys (arrow, space, punctuation).

**Root cause:** The auto-restore logic checks if `raw_input` exists in the English dictionary. Since "dd" is in the dictionary and the buffer "đ" (with no vowel) is considered invalid Vietnamese, the code incorrectly restored to "DD".

**Solution:** Added special case to skip auto-restore when buffer contains only a single stroked character (standalone đ/Đ).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- Added test `standalone_stroke_not_restored_on_break` covering:
  - Standalone "Đ" + RIGHT arrow → stays "Đ"
  - Standalone "đ" + SPACE → stays "đ"
  - Standalone "Đ" + DOT → stays "Đ"

## Checklist

- [x] Tests pass (772+ tests)
- [x] Documentation updated (inline comments)
- [ ] CHANGELOG.md updated
