### PR TITLE
fix(engine): mark key should not cross syllable boundary when consonant+vowel follows

### DIFF
--- a/core/tests/typing_test.rs
+++ b/core/tests/typing_test.rs
@@ -414,6 +414,8 @@ const TELEX_TYPOS: &[(&str, &str)] = &[
     ("mowficf", "mờicf"), // mời + c (final) + f (letter, same mark as first f)
     // With double final (ch) - mark keys after should be letters
     ("moiwschfs", "mớichfs"), // mới + ch (final) + f,s (letters)
+    // New syllable after closed syllable - vowel+w should NOT apply to previous
+    ("mowifchow", "mờichow"), // mời + ch (final) + ow (new syllable, w is letter)
 ];
 
 // ============================================================


### PR DESCRIPTION
## Description

Mark keys (s, f, r, x, j in Telex) incorrectly modify previous syllable when a new syllable (consonant+vowel) has started.

## Example

- Input: `thuwrgox`
- Expected: `thửgox` (x is letter in new syllable "gox")
- Actual: `thữgo` (x modifies ử, replacing hỏi with ngã)

## Root Cause

1. `try_mark` doesn't check for syllable boundary before applying mark
2. `reposition_tone_if_needed` allows repositioning even when consonant between vowels is NOT a valid Vietnamese final

## Solution

1. Add syllable boundary check in `try_mark` - if consonant+vowel after target position, pass mark key as letter
2. In `reposition_tone_if_needed` - check if consonant between vowels is valid final (n, m, c, t, p, ng, nh, ch). If not, it's a new syllable initial.

## Type of Change

- [x] Bug fix

## Testing

- `thuwrgox` → `thửgox`
- `dduowjckho` → `đượckho`
