### PR TITLE
fix(macos): clear buffer on Shift+Home/End selection before Backspace (#251)

### DIFF
--- a/platforms/macos/RustBridge.swift
+++ b/platforms/macos/RustBridge.swift
@@ -46,6 +46,10 @@ private enum KeyCode {
     static let rightArrow: CGKeyCode = 0x7C
     static let downArrow: CGKeyCode = 0x7D
     static let upArrow: CGKeyCode = 0x7E
+    static let home: CGKeyCode = 0x73
+    static let end: CGKeyCode = 0x77
+    static let pageUp: CGKeyCode = 0x74
+    static let pageDown: CGKeyCode = 0x79
     static let space: CGKeyCode = 0x31
     static let tab: CGKeyCode = 0x30
     static let returnKey: CGKeyCode = 0x24
@@ -1070,16 +1074,21 @@ private func keyboardCallback(
     }
 
     // Arrow keys with any modifier (Cmd/Option/Shift) that moves cursor - clear buffer
-    // Cmd+Arrow: move by line, Option+Arrow: move by word, Shift+: select
+    // Cmd+Arrow: move by line, Option+Arrow: move by word, Shift+Arrow: select
+    // Also: Shift+Home/End/PageUp/PageDown for text selection (Issue #251)
     // All of these invalidate the current composition context
-    let arrowKeys: Set<UInt16> = [
+    let navigationKeys: Set<UInt16> = [
         UInt16(KeyCode.leftArrow),   // 0x7B
         UInt16(KeyCode.rightArrow),  // 0x7C
         UInt16(KeyCode.upArrow),     // 0x7E
         UInt16(KeyCode.downArrow),   // 0x7D
+        UInt16(KeyCode.home),        // 0x73
+        UInt16(KeyCode.end),         // 0x77
+        UInt16(KeyCode.pageUp),      // 0x74
+        UInt16(KeyCode.pageDown),    // 0x79
     ]
     let hasModifier = flags.contains(.maskCommand) || flags.contains(.maskAlternate) || flags.contains(.maskShift)
-    if arrowKeys.contains(keyCode) && hasModifier {
+    if navigationKeys.contains(keyCode) && hasModifier {
         RustBridge.clearBuffer()
         TextInjector.shared.clearSessionBuffer()
         return Unmanaged.passUnretained(event)


### PR DESCRIPTION
## Description

Fix bug where buffer was not cleared when user selected text with Shift+Home/End and pressed Backspace. The old characters remained in the buffer and appeared when typing new text.

## Type of Change

- [x] Bug fix

## Testing

1. Type "thứ" (with diacritics)
2. Press Shift+Home to select all
3. Press Backspace to delete
4. Type "học" then Space
5. Verify output is "học " (not "thuwhocj ")

## Checklist

- [x] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated