### PR TITLE
fix(engine): recognize remove modifier 'z' after space+delete restore

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -894,16 +894,16 @@ impl Engine {
         // unless they're mark/tone keys (allow "ban" + restore + "s" → "bán")
         if self.restored_pending_clear && keys::is_letter(key) {
             let m = input::get(self.method);
-            let is_mark_or_tone = m.mark(key).is_some() || m.tone(key).is_some();
-            // Clear buffer when letter is NOT a mark/tone modifier:
+            let is_modifier = m.mark(key).is_some() || m.tone(key).is_some() || m.remove(key);
+            // Clear buffer when letter is NOT a modifier (mark/tone/remove):
             // - Vietnamese restored: clear on consonant (vowels may add diacritics)
-            // - ASCII restored: clear on any non-mark/tone letter (consonant OR vowel)
+            // - ASCII restored: clear on any non-modifier letter (consonant OR vowel)
             let should_clear = if self.restored_is_ascii {
-                // Pure ASCII: clear on any letter except mark/tone keys
-                !is_mark_or_tone
+                // Pure ASCII: clear on any letter except modifier keys
+                !is_modifier
             } else {
-                // Vietnamese: clear only on consonant that's not mark/tone
-                keys::is_consonant(key) && !is_mark_or_tone
+                // Vietnamese: clear only on consonant that's not a modifier
+                keys::is_consonant(key) && !is_modifier
             };
             if should_clear {
                 self.clear();

--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -1685,6 +1685,19 @@ fn backspace_after_space_telex_change_mark() {
     );
 }
 
+/// Remove mark after space (khoongf + SPACE + < + z → không)
+/// Bug: 'z' was clearing buffer because it wasn't recognized as a modifier
+#[test]
+fn backspace_after_space_telex_remove_mark() {
+    let mut e = Engine::new();
+    // "khoongf" → "không", then space + backspace + "z" → "không" (remove huyền)
+    let result = type_word(&mut e, "khoongf <z");
+    assert_eq!(
+        result, "không",
+        "không + space + backspace + z should remove huyền → không"
+    );
+}
+
 /// Multiple backspaces to delete chars (doc + SPACE + << + j → dọ)
 #[test]
 fn backspace_after_space_multiple_backspace() {


### PR DESCRIPTION
## Description

Gõ `khoongf<space><delete>z` cho kết quả `khồngz` thay vì `không`.

## Steps to Reproduce

1. Gõ `khoongf` → `không`
2. Nhấn `<space>` → commit word
3. Nhấn `<delete>` → restore buffer
4. Gõ `z` → expected: xóa dấu huyền → `không`

**Actual:** `khồngz`  
**Expected:** `không`

## Root Cause

Trong logic `restored_pending_clear` tại `core/src/engine/mod.rs:895-914`, chỉ check `m.mark(key)` và `m.tone(key)` để quyết định clear buffer. Phím `z` là remove modifier nhưng không được nhận diện → buffer bị clear → `z` thành chữ cái.

## Fix

Thêm `m.remove(key)` vào điều kiện:

```rust
let is_modifier =
    m.mark(key).is_some() || m.tone(key).is_some() || m.remove(key);
