### PR TITLE
fix(engine): auto-restore incorrectly restores valid Vietnamese patterns with medial W modifier (banwfg → bằng)

### DIFF
--- a/core/tests/english_auto_restore_test.rs
+++ b/core/tests/english_auto_restore_test.rs
@@ -1351,3 +1351,31 @@ fn oe_diphthong_typing_orders() {
         ("tose ", "toé "),
     ]);
 }
+
+// =============================================================================
+// PATTERN: W AS MEDIAL VOWEL MODIFIER (NOT INITIAL/FINAL)
+// When W appears after a vowel and before final consonants, it modifies the
+// preceding vowel (a → ă). This should NOT trigger English restore.
+// Examples: "banwfg" → "bằng", "thanwfg" → "thằng"
+// Compare with W at start (west → west) or W at end (law → law)
+// =============================================================================
+
+#[test]
+fn w_medial_vowel_modifier_pattern() {
+    telex_auto_restore(&[
+        // W after vowel 'a', before final consonants 'ng' - valid Vietnamese breve pattern
+        // Pattern: initial + a + consonant + w + tone + final
+        ("banwfg ", "bằng "),   // b-a-n-w-f-g → bằng (w applies breve to a)
+        ("thanwfg ", "thằng "), // th-a-n-w-f-g → thằng
+        ("canwfg ", "cằng "),   // c-a-n-w-f-g → cằng
+        ("manwfg ", "mằng "),   // m-a-n-w-f-g → mằng
+        // Alternate typing order: w before final consonants
+        ("bawngf ", "bằng "),   // b-a-w-n-g-f → bằng (standard order)
+        ("thawngf ", "thằng "), // th-a-w-n-g-f → thằng
+        // With different tones
+        ("banwsg ", "bắng "), // sắc tone
+        ("banwrg ", "bẳng "), // hỏi tone
+        ("banwxg ", "bẵng "), // ngã tone
+        ("banwjg ", "bặng "), // nặng tone
+    ]);
+}


### PR DESCRIPTION
## Description

Trong chế độ auto-restore, các pattern như "banwfg" và "thanwfg" bị restore về dạng raw thay vì giữ kết quả Vietnamese "bằng" và "thằng".

## Steps to Reproduce

1. Bật chế độ auto-restore
2. Gõ "banwfg " (có space)
3. Kết quả: "banwfg " (SAI)
4. Expected: "bằng "

## Root Cause

`has_english_modifier_pattern` xác định sai pattern vì:
- Chỉ có 1 vowel ('a') trước modifier 'f'
- Không nhận ra 'w' là vowel modifier cho 'a' (biến 'a' → 'ă')

## Solution

Thêm logic đặc biệt: skip restore khi W đứng ở vị trí medial (sau vowel, trước final consonants).

## Test Cases

- "banwfg" → "bằng" ✓
- "thanwfg" → "thằng" ✓
- "law" → "law" ✓ (W ở cuối)
- "west" → "west" ✓ (W ở đầu)
