### PR TITLE
fix(engine): preserve space between repeated w-words in auto-restore mode

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -4101,7 +4101,11 @@ impl Engine {
             }
         }
 
-        self.rebuild_from(first_pos)
+        // Use rebuild_from_after_insert because the trigger key (e.g., 'e' in "ware")
+        // was just added to the buffer but NOT yet displayed on screen.
+        // Using rebuild_from would count the new char in backspace, deleting an extra
+        // character (like the space before this word in "ware ware").
+        self.rebuild_from_after_insert(first_pos)
     }
 
     /// Collect vowels from buffer

--- a/core/tests/english_auto_restore_test.rs
+++ b/core/tests/english_auto_restore_test.rs
@@ -205,6 +205,23 @@ fn pattern5_w_vowel_w() {
 }
 
 #[test]
+fn pattern5_repeated_w_words() {
+    // Issue: When typing a w-word twice separated by space, the space should be preserved.
+    // Bug was: "ware ware" → "wareware" (missing space)
+    // The bug occurred because revert_w_as_vowel_transforms used rebuild_from instead of
+    // rebuild_from_after_insert, causing an extra character (the space) to be deleted.
+    telex_auto_restore(&[
+        ("ware ware ", "ware ware "),
+        ("water water ", "water water "),
+        ("winter winter ", "winter winter "),
+        ("window window ", "window window "),
+        ("work work ", "work work "),
+        ("world world ", "world world "),
+        ("wow wow ", "wow wow "),
+    ]);
+}
+
+#[test]
 fn pattern5_double_w_at_start() {
     // Double 'w' at start should collapse to single 'w' when restoring
     telex_auto_restore(&[("wwax ", "wax ")]);


### PR DESCRIPTION
## Description

Khi bật chế độ "Gõ W thành Ư" và "Tự động khôi phục từ tiếng Anh", gõ một từ bắt đầu bằng W hai lần liên tiếp sẽ mất dấu cách giữa hai từ.

**Steps to reproduce:**
1. Bật chế độ Telex với W → Ư
2. Bật tính năng English auto-restore
3. Gõ: `ware<space>ware`

**Expected:** `ware ware`
**Actual:** `wareware`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Root Cause

Trong hàm `revert_w_as_vowel_transforms()`, gọi `rebuild_from()` thay vì `rebuild_from_after_insert()`. Điều này khiến backspace count bao gồm cả ký tự vừa gõ (chưa hiển thị), dẫn đến xóa thêm 1 ký tự (space) từ màn hình.

## Testing

- Thêm test case `pattern5_repeated_w_words` 
- Tất cả tests pass

## Checklist

- [x] Tests pass
- [x] Documentation updated
- [ ] CHANGELOG.md updated
