### PR TITLE
fix(engine): reset auto-capitalize state on cursor change (paste/click)

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -4228,10 +4228,16 @@ impl Engine {
     /// Clear everything including word history
     /// Used when cursor position changes (mouse click, arrow keys, etc.)
     /// to prevent accidental restore from stale history
+    /// Issue #274: Also reset auto-capitalize state to prevent incorrect
+    /// capitalization after paste/cursor change
     pub fn clear_all(&mut self) {
         self.clear();
         self.word_history.clear();
         self.spaces_after_commit = 0;
+        // Issue #274: Reset auto-capitalize state on cursor change
+        // This prevents incorrect capitalization after copy-paste
+        self.pending_capitalize = false;
+        self.saw_sentence_ending = false;
     }
 
     /// Get the full composed buffer as a Vietnamese string with diacritics.


### PR DESCRIPTION
## Description

Fix Issue #274: Chức năng "tự động viết hoa đầu câu" chưa hoạt động đúng logic sau khi copy-paste.

Khi user copy-paste văn bản rồi gõ tiếp, chữ cái đầu tiên bị viết hoa sai do trạng thái pending_capitalize và saw_sentence_ending không được reset khi cursor thay đổi.

**Fix:** Reset 2 biến này trong clear_all() - hàm được gọi khi paste/click/focus change.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- Thêm 2 test cases mới trong auto_capitalize_test.rs:
  - clear_all_resets_pending_capitalize
  - clear_all_resets_saw_sentence_ending
- Chạy cargo test - tất cả 34 auto_capitalize tests pass

## Checklist

- [x] Tests pass
- [x] Documentation updated (inline comments)
- [ ] CHANGELOG.md updated