### PR TITLE
fix(engine): auto-restore "hiss" should return "his"

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -4518,13 +4518,23 @@ impl Engine {
                         if is_double_ss || is_double_ff {
                             let original_lower = stored.to_lowercase();
                             if english_dict::is_english_word(&original_lower) {
-                                // EXCEPTIONS: "off", "iff", "ass" should keep reverted form
+                                // EXCEPTIONS: certain words should keep reverted form (buffer)
+                                // instead of restoring to raw double letter pattern.
+                                // This handles cases where collapsed buffer is more common:
+                                //   "off" → "of" (common word)
+                                //   "iff" → "if" (common word)
+                                //   "ass" → "as" (common word)
+                                //   "hiss" → "his" (common word, more frequent than "hiss")
                                 let is_exception = if chars.len() == 3 {
                                     let first = chars[0].to_ascii_lowercase();
                                     let is_off = first == 'o' && is_double_ff;
                                     let is_iff = first == 'i' && is_double_ff;
                                     let is_ass = first == 'a' && is_double_ss;
                                     is_off || is_iff || is_ass
+                                } else if chars.len() == 4 {
+                                    // 4-char exceptions: "hiss" → "his"
+                                    let first = chars[0].to_ascii_lowercase();
+                                    first == 'h' && is_double_ss
                                 } else {
                                     false
                                 };

--- a/core/tests/data/english_100k_failures_tone.txt
+++ b/core/tests/data/english_100k_failures_tone.txt
@@ -1,7 +1,7 @@
 # English 100k Failures - Tone Markers
 # Cause: words ending with s/f/r/x/j trigger tone marks
 # Format: WORD \t ACTUAL \t BUFFER
-# Total: 1254 (+ 95 both)
+# Total: 1256 (+ 95 both)
 #
 # WORD: English word typed
 # ACTUAL: engine output after space
@@ -309,6 +309,7 @@ lex	lẽ	lẽ
 hays	háy	háy
 defends	đến	đến
 taps	táp	táp
+hiss	his	his
 boar	boả	boả
 kits	kít	kít
 def	dè	dè
@@ -779,6 +780,7 @@ sof	sò	sò
 ror	rỏ	rỏ
 darauf	dầu	dầu
 memes	mếm	mếm
+hass	has	has
 orf	ò	ò
 raps	ráp	ráp
 naf	nà	nà

--- a/core/tests/english_auto_restore_test.rs
+++ b/core/tests/english_auto_restore_test.rs
@@ -717,6 +717,16 @@ fn pattern9_double_ss_english_words() {
 }
 
 #[test]
+fn pattern9_hiss_exception() {
+    // "hiss" is an exception: user typing "hiss" likely wants "his"
+    // (more common word, user typed double 's' to revert sắc mark)
+    // This is similar to "off" → "of", "iff" → "if", "ass" → "as" exceptions
+    telex_auto_restore(&[
+        ("hiss ", "his "), // hiss → his (exception: "his" more common than "hiss")
+    ]);
+}
+
+#[test]
 fn pattern9_double_f_words() {
     // Double 'f' (huyền mark) - need vowel before ff for revert to happen
     telex_auto_restore(&[


### PR DESCRIPTION
## Description

When typing "hiss " in auto-restore mode, the engine returns "hiss" instead of "his".

**Current behavior:** `hiss ` → `hiss `
**Expected behavior:** `hiss ` → `his `

## Reason

User types "his" which becomes "hís" (with sắc mark), then types another 's' to revert the mark. The expected result is "his", not "hiss".

This is similar to existing exceptions:
- "off" → "of"
- "iff" → "if"  
- "ass" → "as"

## Type of Change

- [x] Bug fix