### PR TITLE
fix(engine): auto-restore "perrmission" should return "permission"

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -5768,7 +5768,7 @@ impl Engine {
 
         // Common English prefixes that suggest intentional revert
         const PREFIXES: &[&str] = &[
-            "dis", "mis", "un", "re", "de", "pre", "anti", "non", "sub", "trans", "con",
+            "dis", "mis", "un", "re", "de", "pre", "per", "anti", "non", "sub", "trans", "con",
         ];
 
         // Common English suffixes

--- a/core/tests/english_auto_restore_test.rs
+++ b/core/tests/english_auto_restore_test.rs
@@ -647,6 +647,20 @@ fn pattern9_re_prefix() {
 }
 
 #[test]
+fn pattern9_per_prefix() {
+    // "per-" prefix: double 'r' (hỏi) reverts mark, buffer has valid prefix pattern
+    // Pattern: per + rr → "pẻr" → "per" (revert)
+    telex_auto_restore(&[
+        ("perrmission ", "permission "),
+        ("perrfect ", "perfect "),
+        ("perrform ", "perform "),
+        ("perrson ", "person "),
+        ("perrsist ", "persist "),
+        ("perrmanent ", "permanent "),
+    ]);
+}
+
+#[test]
 fn pattern9_double_mark_no_prefix() {
     // Words with double mark keys but NO matching prefix/suffix pattern
     // 5+ char words: restore to English (preserve double letter)


### PR DESCRIPTION
## Description

When typing "perrmission " in auto-restore mode, the engine keeps "perrmission" instead of collapsing to "permission".

**Current behavior:** `perrmission ` → `perrmission `
**Expected behavior:** `perrmission ` → `permission `

## Reason

User types "permission" but the 'e' gets hỏi mark (pẻr-), then types another 'r' to revert. The expected result is "permission" with collapsed double 'r'.

## Solution

Added "per" to the PREFIXES list in `should_use_buffer_for_revert()`. The "per-" prefix is common in English: permission, perform, person, perfect, persist, permanent, etc.

## Type of Change

- [x] Bug fix