### PR TITLE
fix(engine): collapse double vowel correctly in auto-restore mode

### DIFF
--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -3669,3 +3669,27 @@ fn standalone_stroke_not_restored_on_break() {
         "Standalone Đ should NOT be restored on punctuation"
     );
 }
+
+// Test case for Issue: dataabase → database (double vowel revert + auto-restore)
+#[test]
+fn test_dataabase_auto_restore() {
+    let mut e = Engine::new();
+    e.set_english_auto_restore(true);
+    let result = type_word(&mut e, "dataabase ");
+    assert_eq!(
+        result, "database ",
+        "dataabase should auto-restore to database"
+    );
+}
+
+// Test case: chooose → choose (triple vowel collapse, NOT further to chose)
+#[test]
+fn test_chooose_auto_restore() {
+    let mut e = Engine::new();
+    e.set_english_auto_restore(true);
+    let result = type_word(&mut e, "chooose ");
+    assert_eq!(
+        result, "choose ",
+        "chooose should auto-restore to choose, not chose"
+    );
+}


### PR DESCRIPTION
## Description

Ở chế độ auto-restore, khi gõ từ tiếng Anh có double vowel từ circumflex revert, kết quả không đúng.

Bug 1: dataabase → dataabase (không restore). Expected: database

Bug 2: chooose → chose (collapse quá mức). Expected: choose

## Root Cause

Logic build_raw_chars() chỉ collapse double vowel ở cuối từ, không xử lý double vowel ở giữa từ.

## Solution

Sửa logic collapse double vowel:
- Step 3a: Double vowel ở cuối → luôn collapse
- Step 3b: Double vowel ở giữa → collapse CHỈ KHI form hiện tại KHÔNG phải English word VÀ form collapsed LÀ English word

## Type of Change

- [x] Bug fix

## Testing

```bash
cargo test test_dataabase_auto_restore
cargo test test_chooose_auto_restore
cargo test
```

## Checklist

- [x] Tests pass
