### PR TITLE
fix(macos): clear engine buffer on Option+Backspace word deletion

### DIFF
--- a/platforms/macos/RustBridge.swift
+++ b/platforms/macos/RustBridge.swift
@@ -1222,6 +1222,14 @@ private func keyboardCallback(
         return Unmanaged.passUnretained(event)
     }
 
+    // Issue #293: Option+Backspace deletes whole word at OS level
+    // Clear engine buffer so state doesn't become stale after word deletion
+    if keyCode == KeyCode.backspace && hasOption && !bypassIME {
+        RustBridge.clearBuffer()
+        TextInjector.shared.clearSessionBuffer()
+        return Unmanaged.passUnretained(event)
+    }
+
     // Backspace handling: try to restore word from screen when backspacing into it
     // This enables editing marks on previously committed words
     if keyCode == KeyCode.backspace && !bypassIME {


### PR DESCRIPTION
## Description

Khi nhấn Option+Backspace, macOS xóa cả từ nhưng engine vẫn giữ buffer cũ. Điều này làm cho trạng thái engine bị lệch so với text thực tế trên màn hình, dẫn đến việc không thể gõ dấu được.

Fix: Detect Option+Backspace → clear engine buffer → pass event qua để OS xử lý việc xóa từ.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

1. Gõ một từ có dấu (ví dụ: "chào")
2. Nhấn Option+Backspace để xóa cả từ
3. Gõ từ mới có dấu → dấu hoạt động bình thường

## Checklist

- [x] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated
