### PR TITLE
fix(macos): clear engine buffer on Command+Delete/Backspace line deletion

### DIFF
--- a/platforms/macos/RustBridge.swift
+++ b/platforms/macos/RustBridge.swift
@@ -1195,14 +1195,16 @@ private func keyboardCallback(
             0x09,  // Cmd+V (paste)
             0x07,  // Cmd+X (cut)
             0x06,  // Cmd+Z (undo)
+            0x33,  // Cmd+Backspace (delete to beginning of line)
+            0x75,  // Cmd+Delete (delete to end of line)
         ]
 
         if textModifyingKeys.contains(keyCode) {
             RustBridge.clearBuffer()
 
             if method == .selectAll {
-                if keyCode == 0x00 {
-                    // Cmd+A: clear session buffer, let next backspace pass through to delete selection
+                if keyCode == 0x00 || keyCode == 0x33 || keyCode == 0x75 {
+                    // Cmd+A, Cmd+Backspace, Cmd+Delete: clear session buffer
                     TextInjector.shared.clearSessionBuffer()
                 } else {
                     // Cmd+V, Cmd+X, Cmd+Z: sync session buffer from field after action completes


### PR DESCRIPTION
## Description

Khi nhấn Command+Delete (xóa đến cuối dòng) hoặc Command+Backspace (xóa đến đầu dòng), macOS xóa text nhưng engine buffer không được clear, gây ra lỗi biến đổi tiếng Việt khi gõ tiếp.

## Steps to Reproduce

1. Gõ một từ tiếng Việt (ví dụ: "chào")
2. Nhấn Command+Delete hoặc Command+Backspace để xóa cả dòng
3. Gõ tiếp → bị lỗi dấu/biến đổi sai

## Root Cause

`textModifyingKeys` chỉ bao gồm Cmd+A/V/X/Z mà thiếu Cmd+Backspace (0x33) và Cmd+Delete (0x75).

## Solution

Thêm keycode 0x33 và 0x75 vào `textModifyingKeys` và clear session buffer tương tự như Cmd+A.

## Related

Tương tự Issue #293 (Option+Backspace)
