### PR TITLE
fix(macos): correct character count to UTF-16 conversion in axDirect injection

### DIFF
--- a/platforms/macos/RustBridge.swift
+++ b/platforms/macos/RustBridge.swift
@@ -390,12 +390,15 @@ private class TextInjector {
         }
 
         // Calculate replacement: delete `bs` chars before cursor, insert `text`
-        // IMPORTANT: cursor and bs are UTF-16 offsets, not grapheme cluster counts
+        // IMPORTANT: cursor is UTF-16 offset (from AX API), but bs is CHARACTER count (from Rust engine)
+        // We need to convert bs characters to UTF-16 offset for correct deletion
         let userUTF16 = userText.utf16
-        let deleteStartUTF16 = max(0, cursorUTF16 - bs)
 
-        // Convert UTF-16 offsets to String.Index
-        let prefixEndIdx = userUTF16.index(userUTF16.startIndex, offsetBy: min(deleteStartUTF16, userUTF16.count))
+        // Convert character count (bs) to UTF-16 offset
+        // Count back `bs` characters from end of userText, then find the UTF-16 offset
+        let charCount = userText.count
+        let charsToKeep = max(0, charCount - bs)
+        let prefixEndIdx = userText.index(userText.startIndex, offsetBy: charsToKeep)
         let suffixStartIdx = userUTF16.index(userUTF16.startIndex, offsetBy: min(cursorUTF16, userUTF16.count))
 
         let prefix = String(userText[..<prefixEndIdx])
@@ -409,7 +412,9 @@ private class TextInjector {
         }
 
         // Update cursor to end of inserted text (use UTF-16 offset)
-        var newCursor = CFRange(location: deleteStartUTF16 + text.utf16.count, length: 0)
+        // Calculate the new cursor position: prefix length (in UTF-16) + inserted text length (in UTF-16)
+        let prefixUTF16Count = prefix.utf16.count
+        var newCursor = CFRange(location: prefixUTF16Count + text.utf16.count, length: 0)
         if let newRange = AXValueCreate(.cfRange, &newCursor) {
             AXUIElementSetAttributeValue(axEl, kAXSelectedTextRangeAttribute as CFString, newRange)
         }


### PR DESCRIPTION
## Description

Fix lỗi gõ "truy cập" thành "truy âập" khi sử dụng Telex trên các app dùng axDirect injection (Dia browser, Zen browser, Spotlight...).

**Nguyên nhân:** Tham số `bs` (backspace count) từ Rust engine là số **ký tự** (character/grapheme), nhưng code cũ xử lý như **UTF-16 offset**, gây xóa sai số lượng ký tự trước khi chèn ký tự có dấu.

**Fix:** Chuyển đổi `bs` từ character count sang UTF-16 offset đúng cách bằng cách đếm ngược `bs` ký tự từ vị trí cursor.

Closes #303

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- Build thành công trên macOS
- Cần test thủ công: gõ "truy cập", "cập nhật" trong Spotlight, Dia browser, Zen browser

## Checklist

- [x] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated
