### PR TITLE
fix(engine): raw_input out of sync after auto-restore + backspace

### DIFF
--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -3756,6 +3756,20 @@ fn test_data_double_backspace_ata_auto_restore() {
     assert_eq!(result, "data ", "data<<ata should auto-restore to data");
 }
 
+// Test case: perfec<<<<rfec (4 backspaces after auto-restore, then retype)
+// After "perfec" auto-restores, 4 backspaces should leave "pe", then "rfec" → "perfec"
+// Bug: raw_input was incorrectly popping 'f' (letter) as stale mark key
+#[test]
+fn test_perfec_4backspace_rfec_auto_restore() {
+    let mut e = Engine::new();
+    e.set_english_auto_restore(true);
+    let result = type_word(&mut e, "perfec<<<<rfec");
+    assert_eq!(
+        result, "perfec",
+        "perfec<<<<rfec should give perfec (raw_input sync after auto-restore)"
+    );
+}
+
 // Test case: abc + space + ook + space
 // Fixed: "abc ôk " (circumflex from intentional double vowel is preserved)
 #[test]


### PR DESCRIPTION
## Description

When typing `perfec<<<<rfec` in auto-restore mode, the result is `prfec` instead of `perfec`.

## Steps to Reproduce

1. Enable English auto-restore mode
2. Type `perfec` → auto-restores correctly to `perfec`
3. Press backspace 4 times → screen shows `pe`
4. Type `rfec`
5. Expected: `perfec`, Actual: `prfec`

## Root Cause

After mid-word auto-restore rebuilds buffer with plain chars, `had_any_transform` flag is not reset. On backspace, stale mark key detection incorrectly pops `f` from `raw_input` because `keys::F` is in `mark_keys` array.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- Added test case `test_perfec_4backspace_rfec_auto_restore`
- All existing tests pass
