### PR TITLE
fix(macos): use clearBufferAll for text-modifying Cmd shortcuts to prevent duplicate words

### DIFF
--- a/platforms/macos/RustBridge.swift
+++ b/platforms/macos/RustBridge.swift
@@ -1169,7 +1169,7 @@ private func keyboardCallback(
         ]
 
         if textModifyingKeys.contains(keyCode) {
-            RustBridge.clearBuffer()
+            RustBridge.clearBufferAll()
         }
         // Pass through all Cmd shortcuts
         return Unmanaged.passUnretained(event)


### PR DESCRIPTION
## Description

Fix duplicate word bug where typing "em " → Cmd+A → Backspace → "em" produces "emem" instead of "em" in apps like Edge and Zalo.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Root Cause

When Cmd+A (and other text-modifying Cmd shortcuts) is pressed, the handler calls `clearBuffer()` which only clears the active buffer (`buf`, `raw_input`) but **preserves `word_history` and `spaces_after_commit`**. This causes the backspace-after-space restore feature to erroneously restore stale words from history.

**Step-by-step:**
1. Typing "em " commits "em" to `word_history` with `spaces_after_commit = 1`
2. Cmd+A calls `clearBuffer()` — `word_history` still contains "em"
3. Backspace triggers the restore feature, popping "em" from stale history back into the engine buffer
4. Typing "em" again composes with the stale buffer, producing "emem"

## Fix

Changed `clearBuffer()` → `clearBufferAll()` for text-modifying Cmd shortcuts (Cmd+A, Cmd+V, Cmd+X, Cmd+Z, Cmd+Backspace, Cmd+Delete). `clearBufferAll()` additionally clears `word_history` and `spaces_after_commit`, preventing stale history from being restored.

This is consistent with how mouse clicks already use `clearBufferAll()` (line 718) for the same reason — cursor position/content changes invalidate word history.

**Changed file(s):** `platforms/macos/RustBridge.swift` (Cmd+key shortcut handler, line 1172)

## Testing

1. Open Edge or Zalo
2. Type "em " (with a trailing space)
3. Press Cmd+A to select all
4. Press Backspace to delete
5. Type "em" again
6. **Expected:** "em" appears (not "emem")
7. Also verify: typing "em " then immediately pressing Backspace still correctly restores "em" (backspace-after-space feature still works in normal flow)

## Checklist

- [ ] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated
