### PR TITLE
fix(engine): stroke modifier not recognized after backspace-after-space restore

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -1019,7 +1019,8 @@ impl Engine {
         // unless they're mark/tone keys (allow "ban" + restore + "s" → "bán")
         if self.restored_pending_clear && keys::is_letter(key) {
             let m = input::get(self.method);
-            let is_modifier = m.mark(key).is_some() || m.tone(key).is_some() || m.remove(key);
+            let is_modifier =
+                m.mark(key).is_some() || m.tone(key).is_some() || m.remove(key) || m.stroke(key);
             // Clear buffer when letter is NOT a modifier (mark/tone/remove):
             // - Vietnamese restored: clear on consonant (vowels may add diacritics)
             // - ASCII restored: clear on any non-modifier letter (consonant OR vowel)

--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -1799,6 +1799,38 @@ fn backspace_after_space_stroke_word() {
     assert_eq!(result, "đí", "Stroke should be preserved after restore");
 }
 
+/// Restore plain word then apply stroke: di + SPACE + DELETE + d → đi
+/// Bug: 'd' was clearing the restored buffer because stroke wasn't recognized as modifier
+#[test]
+fn backspace_after_space_restore_apply_stroke() {
+    let mut e = Engine::new();
+    // "di " + backspace + "d" → "đi" (dd triggers stroke on initial d)
+    let result = type_word(&mut e, "di <d");
+    assert_eq!(
+        result, "đi",
+        "di + space + backspace + d should produce đi (stroke modifier)"
+    );
+}
+
+/// Restore plain word then apply stroke: do + SPACE + DELETE + d → đo
+#[test]
+fn backspace_after_space_restore_apply_stroke_do() {
+    let mut e = Engine::new();
+    let result = type_word(&mut e, "do <d");
+    assert_eq!(result, "đo", "do + space + backspace + d should produce đo");
+}
+
+/// Restore plain word then apply stroke: dua + SPACE + DELETE + d → đua
+#[test]
+fn backspace_after_space_restore_apply_stroke_dua() {
+    let mut e = Engine::new();
+    let result = type_word(&mut e, "dua <d");
+    assert_eq!(
+        result, "đua",
+        "dua + space + backspace + d should produce đua"
+    );
+}
+
 // ============================================================
 // BACKSPACE-AFTER-SPACE: Extended behaviors
 // ============================================================


### PR DESCRIPTION
## Description

Typing `di`, then `<space>`, then `<backspace>`, then `d` produces `did` instead of `đi`.

After restoring a word via backspace-after-space, the engine treats `d` as a regular consonant and clears the buffer before processing. The stroke modifier (`dd→đ`) was missing from the modifier check, so it couldn't combine with the existing `d` in the restored buffer.

## Steps to Reproduce

1. Type `di`
2. Press Space (commits the word)
3. Press Backspace (restores `di` to buffer)
4. Type `d`
5. **Expected:** `đi` — **Actual:** `did`

## Type of Change

- [x] Bug fix

## Testing

- 3 new regression tests added
- All 68 backspace tests pass
- Full test suite passes (22k word coverage, dictionary tests)

## Checklist

- [x] Tests pass
