### PR TITLE
fix(macos): prevent app restart when quitting via Cmd+Q or menu

### DIFF
--- a/platforms/macos/App.swift
+++ b/platforms/macos/App.swift
@@ -13,6 +13,7 @@ struct GoNhanhApp: App {
 
 class AppDelegate: NSObject, NSApplicationDelegate {
     var menuBar: MenuBarController?
+    var isQuitting = false
 
     func applicationDidFinishLaunching(_: Notification) {
         // Register default settings before anything else
@@ -23,6 +24,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Start observing input source changes
         InputSourceObserver.shared.start()
+    }
+
+    func applicationShouldTerminate(_: NSApplication) -> NSApplication.TerminateReply {
+        isQuitting = true
+        return .terminateNow
     }
 
     func applicationWillTerminate(_: Notification) {

--- a/platforms/macos/MenuBar.swift
+++ b/platforms/macos/MenuBar.swift
@@ -470,8 +470,12 @@ class MenuBarController: NSObject, NSWindowDelegate {
         settingsWindow = nil
         NSApp.setActivationPolicy(.accessory)
         // Restart app to reclaim memory if enabled
+        // Skip restart if app is quitting (Cmd+Q or menu Thoát)
+        let isQuitting = (NSApp.delegate as? AppDelegate)?.isQuitting ?? false
+        guard !isQuitting,
+              AppState.shared.advancedMode,
+              AppState.shared.restartOnClose else { return }
         // Terminate first, then relaunch via detached shell script after short delay
-        guard AppState.shared.advancedMode, AppState.shared.restartOnClose else { return }
         let path = Bundle.main.bundleURL.path
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/bin/sh")


### PR DESCRIPTION
## Description

When the "Restart on close" advanced setting is enabled, quitting GoNhanh via **Cmd+Q** or the **"Thoát GoNhanh"** menu item causes the app to restart instead of quitting completely.

When `NSApp.terminate()` is called, macOS closes all windows **before** terminating. This triggers `windowWillClose` on the settings window, which runs the restart logic (launch shell script → reopen app → terminate) — causing an unintended restart loop.

**Fix:** Added `isQuitting` flag in `AppDelegate.applicationShouldTerminate` (fires before windows close). `windowWillClose` now checks this flag and skips restart when the app is intentionally quitting.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

1. Enable **Advanced Mode** → Enable **Restart on close**
2. Open Settings window → Press **Cmd+Q** → App quits completely ✅
3. Open Settings window → Click **close button (X)** → App restarts as expected ✅
4. Quit from menu bar **"Thoát GoNhanh"** while settings is open → App quits completely ✅

## Checklist

- [x] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated
