### PR TITLE
fix(engine): prevent false stroke after circumflex revert on d-initial words

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -1575,8 +1575,12 @@ impl Engine {
         // 3. There must be a non-extending final (t, m, p) between them
         let has_circumflex_trigger_pattern = {
             let first_is_d = buffer_keys.first() == Some(&keys::D);
+            // After circumflex revert (e.g., "dât" → "data"), buffer has [D,A,T,A]
+            // which falsely matches D + V1 + C + V2 pattern. The duplicate vowels are
+            // from the revert, not intentional Vietnamese input, so skip detection.
+            let after_revert = self.had_circumflex_revert;
 
-            if first_is_d {
+            if first_is_d && !after_revert {
                 let vowel_positions: Vec<(usize, u16)> = buffer_keys
                     .iter()
                     .enumerate()

--- a/core/tests/bug_reports_test.rs
+++ b/core/tests/bug_reports_test.rs
@@ -1941,3 +1941,19 @@ fn bug_sess_auto_restore() {
         ("hiss ", "his "), // hiss → his (exception)
     ]);
 }
+
+// =============================================================================
+// BUG: "dataad" → "đata", expected "datad"
+// After circumflex revert (dât → data), buffer [D,A,T,A] falsely matches
+// has_circumflex_trigger_pattern in try_stroke, causing final 'd' to apply
+// stroke on initial 'd'.
+// Fix: Skip circumflex trigger pattern when had_circumflex_revert is true.
+// =============================================================================
+
+#[test]
+fn bug_dataad_false_stroke_after_circumflex_revert() {
+    telex(&[
+        ("dataad", "datad"), // aa revert + d should NOT stroke
+        ("dduotoj", "đuột"), // legitimate stroke still works
+    ]);
+}

--- a/core/tests/data/english_100k_failures.txt
+++ b/core/tests/data/english_100k_failures.txt
@@ -1,6 +1,6 @@
 # English 100k Typing Variants Failures
 # Format: WORD \t VARIANT \t EXPECTED \t ACTUAL \t BUFFER
-# Total failures: 396
+# Total failures: 395
 
 been	been	been	bên	bên
 see	see	see	sê	sê
@@ -25,7 +25,6 @@ roof	roof	roof	rồ	rôf
 thee	thee	thee	thê	thê
 beer	beer	beer	bể	bêr
 choosing	chooosing	choosing	chooing	chôosing
-deemed	deeemed	deemed	đeeme	dêemed
 keeps	keeps	keeps	kếp	kêps
 dawn	dawn	dawn	dăn	dăn
 bow	bow	bow	bơ	bơ


### PR DESCRIPTION
## Description

Khi gõ `dataad`, kết quả hiển thị là `đata` thay vì `datad`.

Sau khi hoàn nguyên dấu mũ (`dât` → `data`), bộ đệm `[D, A, T, A]` bị nhận nhầm là `has_circumflex_trigger_pattern` trong `try_stroke`, khiến ký tự `d` cuối cùng kích hoạt stroke sai.

Sửa bằng cách thêm điều kiện `!self.had_circumflex_revert` để bỏ qua pattern khi nguyên âm trùng lặp đến từ hoàn nguyên.

## Type of Change

- [x] Sửa lỗi

## Testing

- `cargo test` — tất cả test pass
- Gõ thủ công `dataad` → kết quả `datad` ✅

## Checklist

- [x] Test pass
