### PR TITLE
fix(macos): Cmd+Q does not fully quit — app restarts instead

### DIFF
--- a/platforms/macos/App.swift
+++ b/platforms/macos/App.swift
@@ -13,8 +13,6 @@ struct GoNhanhApp: App {
 
 class AppDelegate: NSObject, NSApplicationDelegate {
     var menuBar: MenuBarController?
-    var isQuitting = false
-
     func applicationDidFinishLaunching(_: Notification) {
         // Register default settings before anything else
         registerDefaultSettings()
@@ -26,12 +24,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         InputSourceObserver.shared.start()
     }
 
-    func applicationShouldTerminate(_: NSApplication) -> NSApplication.TerminateReply {
-        isQuitting = true
-        return .terminateNow
-    }
-
     func applicationWillTerminate(_: Notification) {
+        // Cancel any pending restart-on-close (window may have closed during quit)
+        menuBar?.cancelPendingRestart()
         KeyboardHookManager.shared.stop()
         InputSourceObserver.shared.stop()
     }

--- a/platforms/macos/MenuBar.swift
+++ b/platforms/macos/MenuBar.swift
@@ -20,6 +20,7 @@ class MenuBarController: NSObject, NSWindowDelegate {
 
     private let appState = AppState.shared
     private var cancellables = Set<AnyCancellable>()
+    private var pendingRestart: DispatchWorkItem?
 
     override init() {
         super.init()
@@ -485,26 +486,38 @@ class MenuBarController: NSObject, NSWindowDelegate {
         NSApp.mainMenu = mainMenu
     }
 
+    // MARK: - Restart Management
+
+    func cancelPendingRestart() {
+        pendingRestart?.cancel()
+        pendingRestart = nil
+    }
+
     // MARK: - NSWindowDelegate
 
     func windowWillClose(_ notification: Notification) {
         guard let window = notification.object as? NSWindow,
               window === settingsWindow else { return }
+
         window.contentViewController = nil
         settingsWindow = nil
         NSApp.setActivationPolicy(.accessory)
+
         // Restart app to reclaim memory if enabled
-        // Skip restart if app is quitting (Cmd+Q or menu Thoát)
-        let isQuitting = (NSApp.delegate as? AppDelegate)?.isQuitting ?? false
-        guard !isQuitting,
-              AppState.shared.advancedMode,
+        // Use deferred restart: if app is quitting, applicationWillTerminate
+        // will cancel this before it runs
+        guard AppState.shared.advancedMode,
               AppState.shared.restartOnClose else { return }
-        // Terminate first, then relaunch via detached shell script after short delay
         let path = Bundle.main.bundleURL.path
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/bin/sh")
-        task.arguments = ["-c", "sleep 0.5 && open '\(path)'"]
-        try? task.run()
-        NSApp.terminate(nil)
+        let work = DispatchWorkItem { [weak self] in
+            guard self?.pendingRestart?.isCancelled == false else { return }
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: "/bin/sh")
+            task.arguments = ["-c", "sleep 0.5 && open '\(path)'"]
+            try? task.run()
+            NSApp.terminate(nil)
+        }
+        pendingRestart = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: work)
     }
 }


### PR DESCRIPTION
### Problem

Pressing **Cmd+Q** when the Settings window is open causes the app to restart instead of quitting. The menu "Thoát Gõ Nhanh" (from status bar) works correctly.

### Root Cause

In a SwiftUI app with `@main`, Cmd+Q may close windows **before** `applicationShouldTerminate` is called. This means the `isQuitting` flag is still `false` when `windowWillClose` fires, causing the restart-on-close logic (`advancedMode` + `restartOnClose`) to execute unintentionally.

### Fix

Replace the synchronous `isQuitting` flag check with a **deferred restart** approach:

1. `windowWillClose` schedules restart via `DispatchWorkItem` (100ms delay)
2. `applicationWillTerminate` calls `cancelPendingRestart()` to cancel the deferred restart before process exit
3. If user only closes Settings window (not quitting) → restart runs normally

This approach is timing-independent and works regardless of SwiftUI's delegate method ordering.

### Files Changed

- `platforms/macos/MenuBar.swift` — deferred restart via `DispatchWorkItem`, added `cancelPendingRestart()`
- `platforms/macos/App.swift` — call `cancelPendingRestart()` in `applicationWillTerminate`

### Type of Change

- [x] Bug fix

### Testing

1. Open Settings → press Cmd+Q → app should quit completely
2. Open Settings → click close button → app should restart (if `advancedMode` + `restartOnClose` enabled)
3. Click "Thoát Gõ Nhanh" from status bar menu → app should quit completely
