### PR TITLE
fix(engine): horn on 'u' lost after space + backspace in "dươ" pattern

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -907,6 +907,10 @@ impl Engine {
                         // Restore raw_input from buffer (for ESC restore to work)
                         self.restore_raw_input_from_buffer(&restored_buf);
                         self.buf = restored_buf;
+                        // Re-detect pending_u_horn_pos for "uơ" pattern at end of buffer
+                        // This state is lost on clear() but needed for correct horn placement
+                        // Example: "duơ" restored → type "c" → should become "dươc"
+                        self.re_detect_pending_u_horn();
                         // Mark that buffer was restored - if user types new letter,
                         // clear buffer first (they want fresh word, not append)
                         self.restored_pending_clear = true;
@@ -1032,7 +1036,7 @@ impl Engine {
                 // Vietnamese: clear only on consonant that's not a modifier
                 keys::is_consonant(key) && !is_modifier
             };
-            if should_clear {
+            if should_clear && self.pending_u_horn_pos.is_none() {
                 self.clear();
             }
             // Reset flags regardless - user is now actively typing
@@ -4359,6 +4363,26 @@ impl Engine {
         self.restored_pending_clear = false;
         self.restored_is_ascii = false;
         self.shortcut_prefix.clear();
+    }
+
+    /// Re-detect pending_u_horn_pos by scanning buffer for "u(no tone) + o(horn)" pattern
+    /// Used after restoring buffer from word history where this state was lost on clear()
+    fn re_detect_pending_u_horn(&mut self) {
+        self.pending_u_horn_pos = None;
+        let len = self.buf.len();
+        if len < 2 {
+            return;
+        }
+        // Check last two chars for u + ơ pattern (no final consonant after)
+        if let (Some(c1), Some(c2)) = (self.buf.get(len - 2), self.buf.get(len - 1)) {
+            if c1.key == keys::U
+                && c1.tone == tone::NONE
+                && c2.key == keys::O
+                && c2.tone == tone::HORN
+            {
+                self.pending_u_horn_pos = Some(len - 2);
+            }
+        }
     }
 
     /// Clear everything including word history

--- a/core/tests/bug_reports_test.rs
+++ b/core/tests/bug_reports_test.rs
@@ -1957,3 +1957,21 @@ fn bug_dataad_false_stroke_after_circumflex_revert() {
         ("dduotoj", "đuột"), // legitimate stroke still works
     ]);
 }
+
+// =============================================================================
+// BUG: "duow" + space + backspace + "c" → "duơc", expected "dươc"
+// After committing "duơ" with space and restoring via backspace,
+// pending_u_horn_pos is lost. Typing final consonant should apply horn to 'u'.
+// =============================================================================
+
+#[test]
+fn bug_duow_restore_horn() {
+    // "duow " commits "duơ ", backspace restores "duơ", then "c" should produce "dươc"
+    let mut e = Engine::new();
+    let result = type_word(&mut e, "duow <c");
+    println!("'duow <c' -> '{}' (expected: 'dươc')", result);
+    assert_eq!(
+        result, "dươc",
+        "'duow' + space + backspace + 'c' should produce 'dươc'"
+    );
+}


### PR DESCRIPTION
## Issue Description

### Problem

Typing `duow` → space → backspace → `c` produces `duơc` instead of the expected `dươc`. The horn on `u` is lost after committing and restoring the word.

### Root Cause

When `duow` is typed, only `o` gets horn initially (`duơ`), with `pending_u_horn_pos` storing `u`'s position for deferred horn application when a final consonant is added.

On space, `clear()` resets `pending_u_horn_pos = None`. When backspace restores the buffer from `WordHistory`, the pending state is not restored. Additionally, `restored_pending_clear` clears the buffer when the next consonant is typed, so the engine never processes `duơ+c` as a word.

### Fix

- Added `re_detect_pending_u_horn()` to scan restored buffer for `u(no tone) + o(horn)` pattern
- Call it after restoring buffer from word history
- Skip `restored_pending_clear` buffer clear when `pending_u_horn_pos` is set

### Files Changed

- `core/src/engine/mod.rs` — added `re_detect_pending_u_horn()`, restore logic, skip clear
- `core/tests/bug_reports_test.rs` — regression test `bug_duow_restore_horn`

### Type of Change

- [x] Bug fix

### Testing

```bash
cargo test --test bug_reports_test -- bug_duow_restore_horn --nocapture
cargo test  # 851 passed, 0 failed
```

### Checklist

- [x] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated
