### PR TITLE
fix(engine): buffer not restored after break key + backspace

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -807,6 +807,16 @@ impl Engine {
             let continuing_prefix = self.buf.is_empty() && !self.shortcut_prefix.is_empty();
 
             if at_true_start || continuing_prefix {
+                // Track additional break chars for backspace-after-break restore
+                // When user types multiple break chars after a word (e.g., "duow;;"),
+                // each break char should count as one "space" for restore purposes.
+                // Without this, only the first break increments sac, so "duow;;" + <<
+                // only needs 1 backspace to restore, and the 2nd backspace deletes
+                // from the restored buffer instead of undoing the 2nd break char.
+                if continuing_prefix && self.spaces_after_commit > 0 {
+                    self.spaces_after_commit = self.spaces_after_commit.saturating_add(1);
+                }
+
                 // Reset has_non_letter_prefix when starting a new shortcut at true start
                 // This ensures shortcuts like "->" work after DELETE cleared the buffer
                 if at_true_start {
@@ -882,9 +892,33 @@ impl Engine {
             }
 
             let restore_result = self.try_auto_restore_on_break();
+
+            // Push buffer to history before clearing (like SPACE handler)
+            // This enables backspace-after-break to restore the word
+            // Example: "ddu." → backspace → "đu" restored → "f" → "đù"
+            if !self.buf.is_empty() {
+                // If auto-restore happened, repopulate buffer with plain chars first
+                if restore_result.action != 0 {
+                    self.buf.clear();
+                    for &(key, caps, _) in &self.raw_input {
+                        self.buf.push(Char::new(key, caps));
+                    }
+                }
+                self.word_history.push(self.buf.clone());
+                self.spaces_after_commit = 1; // Break char counts as 1 space for restore
+            } else if self.spaces_after_commit > 0 && break_key_to_char(key, shift).is_some() {
+                // Buffer is empty but we recently committed a word (via space or break),
+                // AND this break key produces a visible character (punctuation like ; , .).
+                // Increment counter so backspace can undo all separators before restoring.
+                // Navigation keys (TAB, RETURN, arrows) still clear history since they
+                // indicate the user has moved away from the word.
+                self.spaces_after_commit = self.spaces_after_commit.saturating_add(1);
+            } else {
+                self.word_history.clear();
+                self.spaces_after_commit = 0;
+            }
+
             self.clear();
-            self.word_history.clear();
-            self.spaces_after_commit = 0;
 
             // Issue #130: After clearing buffer, store break char as potential shortcut prefix
             // This allows shortcuts like "->" to work after "abc->" (where "-" clears "abc")

--- a/core/tests/bug_reports_test.rs
+++ b/core/tests/bug_reports_test.rs
@@ -1975,3 +1975,73 @@ fn bug_duow_restore_horn() {
         "'duow' + space + backspace + 'c' should produce 'dươc'"
     );
 }
+
+// =============================================================================
+// BUG: "ddu." + backspace + "f" → "đuf", expected "đù"
+// After committing "đu" with period and deleting period via backspace,
+// the buffer should be restored so "f" applies huyền to "u".
+// =============================================================================
+
+#[test]
+fn bug_ddu_break_backspace_tone() {
+    let mut e = Engine::new();
+    let result = type_word(&mut e, "ddu.<f");
+    println!("'ddu.<f' -> '{}' (expected: 'đù')", result);
+    assert_eq!(
+        result, "đù",
+        "'ddu' + '.' + backspace + 'f' should produce 'đù'"
+    );
+}
+
+// =============================================================================
+// BUG: "dduow." + backspace + "c" → "đuơc", expected "đươc"
+// After committing "đươ" with period and deleting period via backspace,
+// the buffer should be restored with pending_u_horn_pos so "c" completes "đươc".
+// =============================================================================
+
+#[test]
+fn bug_dduow_break_backspace_final() {
+    let mut e = Engine::new();
+    let result = type_word(&mut e, "dduow.<c");
+    println!("'dduow.<c' -> '{}' (expected: 'đươc')", result);
+    assert_eq!(
+        result, "đươc",
+        "'dduow' + '.' + backspace + 'c' should produce 'đươc'"
+    );
+}
+
+// =============================================================================
+// BUG: "duow;;" + backspace×2 + "c" → "dưc", expected "dươc"
+// When multiple break chars follow a word, each should count as one "space"
+// for backspace-after-break restore. Without this, the second backspace
+// deletes from the restored buffer instead of undoing the second break char.
+// =============================================================================
+
+#[test]
+fn bug_duow_double_break_backspace_horn() {
+    let mut e = Engine::new();
+    let result = type_word(&mut e, "duow;;<<c");
+    println!("'duow;;<<c' -> '{}' (expected: 'dươc')", result);
+    assert_eq!(
+        result, "dươc",
+        "'duow' + ';;' + backspace×2 + 'c' should produce 'dươc'"
+    );
+}
+
+// =============================================================================
+// BUG: "dduowc" + space + ";" + backspace×2 + "j" → "đươcj", expected "được"
+// After committing "đươc" with space, break key ";" counts as another
+// separator. Both backspaces undo separators, restoring "đươc", then "j"
+// applies nặng mark → "được".
+// =============================================================================
+
+#[test]
+fn bug_dduowc_restore_backspace_mark() {
+    let mut e = Engine::new();
+    let result = type_word(&mut e, "dduowc ;<<j");
+    println!("'dduowc ;<<j' -> '{}' (expected: 'được')", result);
+    assert_eq!(
+        result, "được",
+        "'dduowc' + space + ';' + backspace×2 + 'j' should produce 'được'"
+    );
+}

--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -1706,19 +1706,21 @@ fn backspace_after_space_second_is_normal() {
     assert_eq!(result, "d", "Second backspace should delete normally");
 }
 
-/// Break key clears history (punctuation)
+/// Break key (punctuation) after space preserves history
+/// Punctuation like comma/semicolon after space acts as additional separator.
+/// Both space and punctuation must be undone via backspace before word is restored.
 #[test]
 fn backspace_after_space_break_clears_history() {
     let mut e = Engine::new();
     // Type "du", space, comma (break key), then backspace
-    // Comma clears history, so backspace should just delete comma
+    // Comma increments sac to 2 - first backspace undoes comma, second restores
     type_word(&mut e, "du ");
-    e.on_key(keys::COMMA, false, false); // Break key clears history
+    e.on_key(keys::COMMA, false, false); // Punctuation break preserves history
     let r = e.on_key(keys::DELETE, false, false);
     assert_eq!(
         r.action,
-        Action::None as u8,
-        "After break key, backspace is normal"
+        Action::Send as u8,
+        "After punctuation break, backspace undoes separator (sac 2→1)"
     );
 }
 
@@ -1905,14 +1907,18 @@ fn backspace_after_space_esc_clears() {
     assert_eq!(r.action, Action::None as u8, "ESC should clear history");
 }
 
-/// Dot punctuation clears history
+/// Dot punctuation after space preserves history (like comma/semicolon)
 #[test]
 fn backspace_after_space_dot_clears() {
     let mut e = Engine::new();
     type_word(&mut e, "du ");
     e.on_key(keys::DOT, false, false);
     let r = e.on_key(keys::DELETE, false, false);
-    assert_eq!(r.action, Action::None as u8, "DOT should clear history");
+    assert_eq!(
+        r.action,
+        Action::Send as u8,
+        "DOT after space preserves history (sac 2→1)"
+    );
 }
 
 /// Typing new word after space, backspace restores new word only


### PR DESCRIPTION
## Description

Backspace after a break key (`.`, `,`, `;`...) does not restore the word buffer, preventing further editing (tone/mark application).

### Bug

| Input | Current | Expected |
|:---|:---|:---|
| `ddu.<f` | `đuf` | `đù` |
| `dduow.<c` | `đuơc` | `đươc` |
| `duow;;<<c` | `duưc` | `dươc` |
| `dduowc ;<<j` | `đươcj` | `được` |

### Root Cause

1. Break key handler clears `word_history`, unlike SPACE handler which pushes buffer to history before clearing.
2. Multiple consecutive break chars after a word: second break enters shortcut prefix accumulation without incrementing `spaces_after_commit`, so only 1 backspace restores the word — the 2nd backspace deletes from the restored buffer.
3. Punctuation break key (`;`, `,`, `.`) on empty buffer after space clears `word_history` instead of counting as additional separator.

### Fix

1. Mirror SPACE handler pattern: push buffer to `word_history` before `clear()` on break keys, set `spaces_after_commit = 1`.
2. Increment `spaces_after_commit` in the `continuing_prefix` branch when `sac > 0`.
3. When break key produces a visible character (via `break_key_to_char`) and `sac > 0`, increment `sac` instead of clearing history. Navigation keys (TAB, RETURN, arrows) still clear.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- Added 4 test cases in `bug_reports_test.rs`
- Updated 2 integration tests to match new break-key-after-space behavior
- Full test suite: all existing tests pass (0 regressions)

## Checklist

- [x] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated
