### PR TITLE
fix(engine): multi-word chained restore via continuous backspace

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -1038,6 +1038,16 @@ impl Engine {
             // If buffer still has chars, user might think they cleared everything
             // but actually didn't - let them start fresh on next letter input
             if self.buf.is_empty() {
+                // Chain-restore: when a restored buffer is fully deleted via continuous
+                // backspaces and word_history has more entries, enable restoring the
+                // previous word on the next backspace. The `restored_pending_clear` flag
+                // ensures this only happens in continuous backspace sequences — if the
+                // user typed any letter (which clears the flag), the chain breaks.
+                // Example: "dươc vẫn " → bs restores "vẫn" → bs×3 deletes it →
+                //          bs restores "dươc" → "j" applies mark → "được"
+                if self.restored_pending_clear && self.word_history.len > 0 {
+                    self.spaces_after_commit = 1;
+                }
                 self.restored_pending_clear = false;
                 // Restore pending_capitalize if user deleted the auto-capitalized letter
                 // This allows: ". B" → delete B → ". " → type again → auto-capitalizes

--- a/core/tests/bug_reports_test.rs
+++ b/core/tests/bug_reports_test.rs
@@ -2045,3 +2045,20 @@ fn bug_dduowc_restore_backspace_mark() {
         "'dduowc' + space + ';' + backspace×2 + 'j' should produce 'được'"
     );
 }
+
+// =============================================================================
+// BUG: "dươc vẫn " + backspace×5 + "j" → "dươcj", expected "dược"
+// Multi-word chained restore: after restoring "vẫn" and deleting it fully,
+// the next backspace should restore the previous word "dươc" from history.
+// =============================================================================
+
+#[test]
+fn bug_multiword_chained_restore_mark() {
+    let mut e = Engine::new();
+    let result = type_word(&mut e, "duowc vaaxn <<<<<j");
+    println!("'duowc vaaxn <<<<<j' -> '{}' (expected: 'dược')", result);
+    assert_eq!(
+        result, "dược",
+        "'duowc' + space + 'vaaxn' + space + bs×5 + 'j' should produce 'dược'"
+    );
+}


### PR DESCRIPTION
## Description

When typing multiple Vietnamese words and pressing backspace continuously to go back to an earlier word for editing, the engine loses track of previous words after the first restore.

### Bug

| Input | Current | Expected |
|:---|:---|:---|
| `duowc vaaxn` + SPACE + bs×5 + `j` | `dươcj` | `dược` |

### Root Cause

After restoring a word from `word_history` and fully deleting it via backspaces, `spaces_after_commit` is 0 and the engine doesn't chain-restore the previous word from history.

### Fix

In the DELETE handler, when a restored buffer is fully emptied by continuous backspaces (`restored_pending_clear == true`) and `word_history` has more entries, set `spaces_after_commit = 1` to enable restoring the previous word on the next backspace.

The `restored_pending_clear` flag gates this — if the user types any letter between backspaces, the chain breaks (no stale restores).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- Added `bug_multiword_chained_restore_mark` test in `bug_reports_test.rs`
- Full test suite: all tests pass (0 regressions)

## Checklist

- [x] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated
