### PR TITLE
fix(engine): auto-restore produces doubled consonant on multiple mark reverts

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -5956,6 +5956,37 @@ impl Engine {
                 }
             }
 
+            // 5. Dictionary-based double consonant collapse (ss, ff, rr, etc.)
+            // Handles mark revert artifacts from multiple reverts in the same word.
+            // Example: "bussiness" (from b-u-s-s-i-n-e-s-s) → "business"
+            // The first ss revert bakes "ss" into raw_input, then the second ss revert
+            // captures it again in telex_double_raw, producing a doubled consonant.
+            // Only collapse when:
+            //   - Current form is NOT in dictionary, AND
+            //   - Collapsed form IS in dictionary
+            //   - Double consonant is NOT at the very end (preserve "bass", "staff", "class")
+            if chars.len() >= 3 {
+                let current_str: String = chars.iter().collect::<String>().trim().to_lowercase();
+                if !english_dict::is_english_word(&current_str) {
+                    let mut i = 0;
+                    while i + 2 < chars.len() {
+                        let c = chars[i].to_ascii_lowercase();
+                        let next = chars[i + 1].to_ascii_lowercase();
+                        if matches!(c, 's' | 'f' | 'r' | 'x' | 'j') && c == next {
+                            let mut collapsed = chars.clone();
+                            collapsed.remove(i);
+                            let collapsed_str: String =
+                                collapsed.iter().collect::<String>().trim().to_lowercase();
+                            if english_dict::is_english_word(&collapsed_str) {
+                                chars = collapsed;
+                                continue;
+                            }
+                        }
+                        i += 1;
+                    }
+                }
+            }
+
             // Partial restore: Telex tone modifier + doubled/tripled vowel patterns.
             // Applies the tone mark to the correct vowel and collapses extra vowels.
             // Works with any consonant cluster length (ch, tr, ng, ngh, etc.)

--- a/core/tests/revert_auto_restore_test.rs
+++ b/core/tests/revert_auto_restore_test.rs
@@ -276,6 +276,17 @@ fn stroke_english_words_restore() {
 }
 
 #[test]
+fn double_revert_collapses_to_english_word() {
+    // When mark is reverted TWICE in the same word, telex_double_raw captures
+    // the raw_input which already contains the first revert's doubled letter.
+    // Dictionary-based consonant collapse should fix this.
+    telex_auto_restore(&[
+        // b-u-s-s-i-n-e-s-s → "bussiness" raw → collapse to "business"
+        ("bussiness ", "business "),
+    ]);
+}
+
+#[test]
 fn common_vietnamese_words_with_tone() {
     // Common Vietnamese words with tone marks should stay Vietnamese
     // These should NOT be in telex_doubles whitelist


### PR DESCRIPTION
## Description

Auto-restore produces doubled consonants when mark is reverted twice within the same word.

**Steps to reproduce:**
1. Enable Vietnamese mode with auto-restore
2. Type `b-u-s` → `bú` (sắc applied)
3. Type `s` to revert → `bus`
4. Type `i-n-e-s-s` + space → `bussiness` ❌

**Expected:** `business`
**Actual:** `bussiness`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Root Cause

When `revert_mark()` is called a second time within the same word, `telex_double_raw` is overwritten with the full `raw_input` which already contains the `ss` from the first revert. On auto-restore, `collect_raw_chars()` reconstructs `bussiness` instead of `business`.

## Fix

Added dictionary-based double consonant collapse in `build_raw_chars()`:
- If raw string contains a doubled consonant (`ss`, `ff`, `rr`, etc.) in the **middle** of the word
- AND the current form is NOT in the English dictionary
- AND the collapsed form IS in the English dictionary
- → Collapse the double to single

Double consonants at end of word are preserved (`bass`, `class`, `staff`).

## Testing

```bash
cargo test --test revert_auto_restore_test -- --nocapture
cargo test  # full suite: 931 passed, 0 failed
```

## Checklist

- [x] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated
