### PR TITLE
fix(macos): clear buffer on any Cmd+key to prevent cross-tab leak in browsers

### DIFF
--- a/platforms/macos/RustBridge.swift
+++ b/platforms/macos/RustBridge.swift
@@ -1228,20 +1228,10 @@ private func keyboardCallback(
 
     // Pass through all Cmd+key shortcuts (Cmd+A, Cmd+C, Cmd+V, Cmd+X, Cmd+Z, etc.)
     if flags.contains(.maskCommand), !flags.contains(.maskControl), !flags.contains(.maskAlternate) {
-        // Shortcuts that modify text content
-        let textModifyingKeys: Set<UInt16> = [
-            0x00, // Cmd+A (select all)
-            0x09, // Cmd+V (paste)
-            0x07, // Cmd+X (cut)
-            0x06, // Cmd+Z (undo)
-            0x33, // Cmd+Backspace (delete to beginning of line)
-            0x75, // Cmd+Delete (delete to end of line)
-        ]
-
-        if textModifyingKeys.contains(keyCode) {
-            RustBridge.clearBufferAll()
-        }
-        // Pass through all Cmd shortcuts
+        // Any Cmd+key shortcut invalidates the current composition context:
+        // Cmd+T/N/W switches tab/window, Cmd+A/V/X/Z modifies text, Cmd+1-9 switches tabs, etc.
+        // Issue #365: without this, buffer leaks across tab switches (Cmd+T) in browsers.
+        RustBridge.clearBufferAll()
         return Unmanaged.passUnretained(event)
     }
 


### PR DESCRIPTION
## Description

Engine buffer leaks across browser tab switches: typing Vietnamese text, pressing Cmd+T to open a new tab, then continuing to type produces mangled output from the previous tab's stale composition state.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Root Cause

The Cmd+key handler in `keyboardCallback` only cleared the buffer for a hard-coded whitelist of text-modifying shortcuts (Cmd+A/V/X/Z/Backspace/Delete). Shortcuts that change the text context without being on that list — most notably `Cmd+T` (new tab), `Cmd+N` (new window), `Cmd+W` (close tab), `Cmd+Shift+T` (reopen tab), `Cmd+1..9` (switch tab) — passed through without resetting the engine.

Reproduction on Chrome / Brave / Dia:
1. Go to google.com, type `ăn` (no space)
2. Press `Cmd+T` → new tab
3. Type `cơm`, press space
4. Output: `awncowm ` (stale `ăn` concatenated with current composition)

## Fix

Replaced the whitelist with an unconditional `clearBufferAll()` for all `Cmd+key` combinations (excluding those that already have Ctrl or Option modifiers, which route through different branches). Rationale: virtually every Cmd+shortcut either switches focus, opens a dialog, or modifies text — none preserve the current Vietnamese composition context. Simpler and safer than enumerating every tab/window/navigation shortcut per browser.

Edge cases considered:
- `Cmd+Arrow`/`Home`/`End`/`PageUp`/`PageDown`: already handled by the earlier navigation branch (returns before reaching Cmd branch).
- `Cmd+Enter`: handled by the Enter branch earlier.
- `Cmd+C`: clearing is harmless — prior selection (mouse or Shift+Arrow) already clears the buffer.
- `Cmd+B/I/U` (format toggle mid-word): rare; trade-off accepted in exchange for fixing a 100%-reproducible bug.

**Changed file(s):** `platforms/macos/RustBridge.swift` (`keyboardCallback`, Cmd-shortcut pass-through branch)

## Testing

1. Build and install: `make install`
2. Open Chrome (or Brave / Dia), navigate to any page with a text input.
3. Type `ăn` (no trailing space).
4. Press `Cmd+T` to open a new tab, focus the address bar or any input.
5. Type `cơm` then press space.
6. Expected: output is `cơm ` (buffer did not leak from the previous tab).
7. Repeat with `Cmd+W` (close tab) and `Cmd+1`/`Cmd+2` (switch tabs) — no leak in any direction.
8. Regression check: confirm `Cmd+A`, `Cmd+V`, `Cmd+X`, `Cmd+Z`, `Cmd+Backspace`, `Cmd+Delete` still work normally.

## Checklist

- [x] Tests pass (build succeeds)
- [ ] Documentation updated
- [ ] CHANGELOG.md updated

Fixes #365
