### PR TITLE
fix(core): prevent panic in collect_raw_chars when raw_input shorter than telex_double_raw_len

### DIFF
--- a/core/src/engine/mod.rs
+++ b/core/src/engine/mod.rs
@@ -5743,6 +5743,10 @@ impl Engine {
                 } else {
                     self.telex_double_raw_len
                 };
+                // Clamp to raw_input length to avoid out-of-bounds slice when
+                // raw_input has been shortened further (e.g. backspace) after
+                // telex_double_raw was stored.
+                let subsequent_start = subsequent_start.min(self.raw_input.len());
                 for &(key, caps, shift) in &self.raw_input[subsequent_start..] {
                     if let Some(ch) = utils::key_to_char_ext(key, caps, shift) {
                         result.push(ch);


### PR DESCRIPTION
## Description

Fix panic `slice_index_fail` trong `collect_raw_chars` khiến app crash (SIGABRT) khi gõ phím trong một số trường hợp sau khi xảy ra Telex revert (ss/dd/xx...).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Root Cause

Trong `core/src/engine/mod.rs` hàm `collect_raw_chars`, khi `telex_double_raw` đã được lưu và sau đó `raw_input` bị rút ngắn (ví dụ user backspace), `subsequent_start` được tính bằng `telex_double_raw_len.saturating_sub(1)` vẫn có thể lớn hơn `raw_input.len()`.

Ví dụ: `telex_double_raw_len = 3`, `raw_input.len() = 1` → `subsequent_start = 2`, dẫn tới slice `&self.raw_input[2..]` panic vì index out-of-bounds → Rust panic → `abort()`.

Stack trace từ 2 crash report trùng khớp: `collect_raw_chars` → `slice_index_fail` → `rust_panic` → `abort`.

## Fix

Clamp `subsequent_start` về `raw_input.len()` trước khi slice để tránh out-of-bounds. Sibling code tại dòng 4648 dùng `.iter().skip()` (an toàn) nên không cần sửa.

**Changed file(s):** `core/src/engine/mod.rs` (`Engine::collect_raw_chars`)

## Testing

1. Build: `cd core && cargo build --release`
2. Chạy tests: `cargo test` (131 tests pass)
3. Manual:
   - Bật Telex, gõ một từ kích hoạt telex revert (vd: `ss`, `dd`, `xx`)
   - Backspace nhiều lần để rút ngắn buffer xuống dưới `telex_double_raw_len`
   - Tiếp tục gõ phím → app không còn crash

## Checklist

- [x] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated
