### PR TITLE
fix: remote desktop support — passthrough + session tap mode (closes #378)

### DIFF
--- a/platforms/macos/AdvancedSettingsView.swift
+++ b/platforms/macos/AdvancedSettingsView.swift
@@ -12,6 +12,7 @@ struct AdvancedSettingsView: View {
         ScrollView(showsIndicators: false) {
             VStack(alignment: .leading, spacing: 20) {
                 performanceSection
+                compatibilitySection
                 logSection
                 perAppSection
                 Spacer()
@@ -33,6 +34,19 @@ struct AdvancedSettingsView: View {
                 "Khởi động lại khi đóng cài đặt",
                 subtitle: "Tự động giải phóng RAM của cài đặt khi đóng",
                 isOn: $appState.restartOnClose
+            )
+        }
+        .cardBackground()
+    }
+
+    // MARK: - Compatibility
+
+    private var compatibilitySection: some View {
+        VStack(spacing: 0) {
+            SettingsToggleRow(
+                "Chế độ remote desktop",
+                subtitle: "Dùng khi gõ qua RustDesk, AnyDesk, TeamViewer. Bắt synthetic events ở session level thay vì HID level.",
+                isOn: $appState.sessionTapMode
             )
         }
         .cardBackground()

--- a/platforms/macos/App.swift
+++ b/platforms/macos/App.swift
@@ -45,6 +45,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             SettingsKey.soundEnabled: false,
             SettingsKey.allowForeignConsonants: false,
             SettingsKey.advancedMode: false,
+            SettingsKey.sessionTapMode: false,
         ])
     }
 }

--- a/platforms/macos/AppMetadata.swift
+++ b/platforms/macos/AppMetadata.swift
@@ -91,6 +91,7 @@ enum SettingsKey {
     static let perAppProfiles = "gonhanh.perAppProfiles"
     static let disablePanelDetection = "gonhanh.disablePanelDetection"
     static let restartOnClose = "gonhanh.restartOnClose"
+    static let sessionTapMode = "gonhanh.sessionTapMode"
 }
 
 // MARK: - Keyboard Shortcut Model

--- a/platforms/macos/MainSettingsView.swift
+++ b/platforms/macos/MainSettingsView.swift
@@ -184,6 +184,16 @@ class AppState: ObservableObject {
         }
     }
 
+    /// Use cgSessionEventTap instead of cghidEventTap.
+    /// Enables Vietnamese input via remote desktop software (RustDesk, AnyDesk, TeamViewer)
+    /// by intercepting synthetic events injected at session level. Requires app restart to take effect.
+    @Published var sessionTapMode: Bool = false {
+        didSet {
+            UserDefaults.standard.set(sessionTapMode, forKey: SettingsKey.sessionTapMode)
+            KeyboardHookManager.shared.restart()
+        }
+    }
+
     /// Per-app profiles: delay preset + method override per bundleId
     @Published var perAppProfiles: [String: PerAppConfig] = [:] {
         didSet {
@@ -225,6 +235,7 @@ class AppState: ObservableObject {
         advancedMode = defaults.bool(forKey: SettingsKey.advancedMode)
         disablePanelDetection = defaults.bool(forKey: SettingsKey.disablePanelDetection)
         restartOnClose = defaults.bool(forKey: SettingsKey.restartOnClose)
+        sessionTapMode = defaults.bool(forKey: SettingsKey.sessionTapMode)
         if let data = defaults.data(forKey: SettingsKey.perAppProfiles),
            let profiles = try? JSONDecoder().decode([String: PerAppConfig].self, from: data)
         {

--- a/platforms/macos/RustBridge.swift
+++ b/platforms/macos/RustBridge.swift
@@ -755,12 +755,23 @@ class KeyboardHookManager {
         // Listen for keyboard events only (mouse handled by NSEvent monitor)
         let mask: CGEventMask = (1 << CGEventType.keyDown.rawValue) |
             (1 << CGEventType.flagsChanged.rawValue)
-        let tap = CGEvent.tapCreate(tap: .cghidEventTap, place: .headInsertEventTap,
+
+        // Session tap mode: intercept at cgSessionEventTap level so that synthetic events
+        // injected by remote desktop software (RustDesk, AnyDesk, TeamViewer) are visible.
+        // Default (HID tap): highest priority, physical keystrokes only, best for most cases.
+        let tap: CFMachPort?
+        if AppState.shared.sessionTapMode {
+            tap = CGEvent.tapCreate(tap: .cgSessionEventTap, place: .headInsertEventTap,
                                     options: .defaultTap, eventsOfInterest: mask,
                                     callback: keyboardCallback, userInfo: nil)
-            ?? CGEvent.tapCreate(tap: .cgSessionEventTap, place: .headInsertEventTap,
-                                 options: .defaultTap, eventsOfInterest: mask,
-                                 callback: keyboardCallback, userInfo: nil)
+        } else {
+            tap = CGEvent.tapCreate(tap: .cghidEventTap, place: .headInsertEventTap,
+                                    options: .defaultTap, eventsOfInterest: mask,
+                                    callback: keyboardCallback, userInfo: nil)
+                ?? CGEvent.tapCreate(tap: .cgSessionEventTap, place: .headInsertEventTap,
+                                     options: .defaultTap, eventsOfInterest: mask,
+                                     callback: keyboardCallback, userInfo: nil)
+        }
 
         guard let tap else {
             showAccessibilityAlert()
@@ -801,6 +812,13 @@ class KeyboardHookManager {
 
     func getTap() -> CFMachPort? {
         eventTap
+    }
+
+    /// Restart the keyboard hook with the current tap mode setting.
+    /// Called when sessionTapMode is toggled in settings.
+    func restart() {
+        stop()
+        start()
     }
 
     private func showAccessibilityAlert() {

--- a/platforms/macos/RustBridge.swift
+++ b/platforms/macos/RustBridge.swift
@@ -1469,6 +1469,20 @@ private func detectMethod() -> (InjectionMethod, (UInt32, UInt32, UInt32)) {
         return cached(.passthrough, (0, 0, 0), "pass:iphone")
     }
 
+    // Remote desktop clients - pass through all keys
+    // These apps forward physical keystrokes to the remote machine over the network.
+    // GoNhanh's synthetic injections (backspace + Vietnamese char) are NOT forwarded,
+    // causing garbled input on the remote. Passthrough lets raw keys reach the remote
+    // intact; Vietnamese composition must happen on the remote machine itself.
+    let remoteDesktopApps: Set<String> = [
+        "com.carriez.rustdesk",       // RustDesk
+        "com.philandro.anydesk",      // AnyDesk
+        "com.teamviewer.TeamViewer",  // TeamViewer
+    ]
+    if remoteDesktopApps.contains(bundleId) {
+        return cached(.passthrough, (0, 0, 0), "pass:remote")
+    }
+
     // Selection method for autocomplete UI elements
     if role == "AXComboBox" { return cached(.selection, (0, 0, 0), "sel:combo") }
     if role == "AXSearchField" { return cached(.selection, (0, 0, 0), "sel:search") }


### PR DESCRIPTION
## Vấn đề

Gõ Nhanh không hoạt động khi gõ qua remote desktop (RustDesk, AnyDesk, TeamViewer) — dù cài trên máy local hay remote. Chi tiết tại #378.

## Nguyên nhân gốc rễ

GoNhanh hook ở `cghidEventTap` (HID level), chỉ thấy phím từ phần cứng vật lý. Remote desktop software inject keystroke dưới dạng **synthetic events ở session level** (`cgSessionEventTap`), hoàn toàn bypass HID tap.

So sánh: EVKey/OpenKey hoạt động được qua remote desktop vì chúng tap ở session level, không phải HID level.

## Thay đổi

### Commit 1 — Passthrough cho remote desktop clients (máy local)
Ngăn GoNhanh làm loạn input khi RustDesk đang focus trên máy local bằng cách thêm passthrough mode (giống iPhone Mirroring).

### Commit 2 — Session tap mode (fix thực sự)
Thêm toggle **"Chế độ remote desktop"** tại Settings → Nâng cao.

Khi bật: GoNhanh chuyển sang `cgSessionEventTap` → bắt được synthetic events từ RustDesk server trên máy remote → gõ tiếng Việt hoạt động.

**Không có breaking changes:**
- Mặc định tắt — giữ nguyên HID tap, behavior hiện tại không đổi
- GoNhanh đã fallback sang session tap khi HID tap thất bại → app đã hoạt động tốt ở session level
- `kEventMarker` ngăn self-injection loop — cơ chế sẵn có, không cần thay đổi
- Game mode (`syncProxy`), Spotlight detection, mouse monitor — không ảnh hưởng

## Files thay đổi

| File | Thay đổi |
|---|---|
| `RustBridge.swift` | Passthrough cho RustDesk/AnyDesk/TeamViewer; tap level theo setting; `restart()` method |
| `AppMetadata.swift` | `SettingsKey.sessionTapMode` |
| `App.swift` | Register default `sessionTapMode: false` |
| `MainSettingsView.swift` | `AppState.sessionTapMode` với `didSet` restart |
| `AdvancedSettingsView.swift` | Toggle UI "Chế độ remote desktop" |

## Hướng dẫn test

1. Cài GoNhanh trên máy remote (macOS host của RustDesk)
2. Mở Settings → Nâng cao → bật **"Chế độ remote desktop"**
3. Kết nối từ máy khác qua RustDesk → gõ tiếng Việt
