### PR TITLE
fix: support typing via macOS Accessibility Keyboard (#395)

### DIFF
--- a/platforms/macos/AdvancedSettingsView.swift
+++ b/platforms/macos/AdvancedSettingsView.swift
@@ -45,7 +45,7 @@ struct AdvancedSettingsView: View {
         VStack(spacing: 0) {
             SettingsToggleRow(
                 "Chế độ remote desktop",
-                subtitle: "Dùng khi gõ qua RustDesk, AnyDesk, TeamViewer. Bắt synthetic events ở session level thay vì HID level.",
+                subtitle: "Bật khi gõ qua RustDesk, AnyDesk, TeamViewer. Bắt synthetic events ở session level thay vì HID level. (Bàn phím trợ năng / Accessibility Keyboard đã tự động được hỗ trợ.)",
                 isOn: $appState.sessionTapMode
             )
         }

--- a/platforms/macos/MainSettingsView.swift
+++ b/platforms/macos/MainSettingsView.swift
@@ -185,8 +185,10 @@ class AppState: ObservableObject {
     }
 
     /// Use cgSessionEventTap instead of cghidEventTap.
-    /// Enables Vietnamese input via remote desktop software (RustDesk, AnyDesk, TeamViewer)
-    /// by intercepting synthetic events injected at session level. Applied immediately via restart().
+    /// Enables Vietnamese input for keystrokes injected at session level (invisible to the
+    /// default HID tap): the macOS Accessibility Keyboard / on-screen keyboards (issue #395)
+    /// and remote desktop software (RustDesk, AnyDesk, TeamViewer).
+    /// Applied immediately via restart().
     @Published var sessionTapMode: Bool = false {
         didSet {
             UserDefaults.standard.set(sessionTapMode, forKey: SettingsKey.sessionTapMode)

--- a/platforms/macos/RustBridge.swift
+++ b/platforms/macos/RustBridge.swift
@@ -1641,7 +1641,7 @@ private func detectMethod() -> (InjectionMethod, (UInt32, UInt32, UInt32)) {
     // GoNhanh's synthetic injections (backspace + Vietnamese char) are NOT forwarded,
     // causing garbled input on the remote. Passthrough lets raw keys reach the remote
     // intact; Vietnamese composition must happen on the remote machine itself.
-    let remoteDesktopApps: Set<String> = [
+    let remoteDesktopApps: Set = [
         "com.carriez.rustdesk", // RustDesk
         "com.philandro.anydesk", // AnyDesk
         "com.teamviewer.TeamViewer", // TeamViewer

--- a/platforms/macos/RustBridge.swift
+++ b/platforms/macos/RustBridge.swift
@@ -748,6 +748,74 @@ class RustBridge {
     }
 }
 
+// MARK: - Accessibility Keyboard Detection
+
+/// Bundle id of the macOS Accessibility Keyboard panel host (System Settings > Accessibility
+/// > Keyboard). The panel is drawn by the "AssistiveControl" input method
+/// (/System/Library/Input Methods/Assistive Control.app). Bundle id is the canonical,
+/// reverse-DNS, locale-independent identifier — preferred over the window owner name.
+private let kAccessibilityKeyboardBundleId = "com.apple.inputmethod.AssistiveControl"
+
+/// Whether the given CGWindowList entry is owned by the Accessibility Keyboard panel.
+/// Resolves the window's owner PID to its bundle id (the stable identifier).
+private func windowIsAccessibilityKeyboard(_ w: [String: Any]) -> Bool {
+    guard let pid = (w[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value else { return false }
+    return NSRunningApplication(processIdentifier: pid)?.bundleIdentifier == kAccessibilityKeyboardBundleId
+}
+
+/// Whether a click at the given screen point (NSEvent coordinates: bottom-left origin)
+/// lands on the macOS Accessibility Keyboard panel.
+///
+/// Walks the on-screen window list front-to-back and inspects the topmost visible window
+/// containing the point. Only window owner/bounds are read (no titles), so this needs no
+/// Screen Recording permission. Used to avoid clearing the composition buffer when the
+/// user taps a virtual key (issue #395).
+private func isClickOnAccessibilityKeyboard(_ nsPoint: CGPoint) -> Bool {
+    // Convert NSEvent screen coordinates (origin bottom-left of the primary display, y up)
+    // to CoreGraphics global coordinates (origin top-left of the primary display, y down).
+    guard let primary = NSScreen.screens.first else { return false }
+    let point = CGPoint(x: nsPoint.x, y: primary.frame.height - nsPoint.y)
+
+    guard let windows = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID)
+        as? [[String: Any]] else { return false }
+
+    for w in windows {
+        // Skip fully transparent overlay windows that would otherwise shadow the panel.
+        let alpha = (w[kCGWindowAlpha as String] as? NSNumber)?.doubleValue ?? 1.0
+        if alpha <= 0.01 { continue }
+
+        guard let boundsDict = w[kCGWindowBounds as String] as? NSDictionary,
+              let bounds = CGRect(dictionaryRepresentation: boundsDict as CFDictionary),
+              !bounds.isEmpty, bounds.contains(point) else { continue }
+
+        // Topmost visible window under the click — decide based on its owner alone.
+        return windowIsAccessibilityKeyboard(w)
+    }
+    return false
+}
+
+/// Whether the macOS Accessibility Keyboard panel is currently visible on screen.
+///
+/// Its synthetic keystrokes are only visible at the session-level event tap (issue #395),
+/// so when the panel is up we transparently switch to that tap even if the user hasn't
+/// enabled the manual "remote desktop" toggle. Detects the panel (not just the background
+/// process) by requiring a panel-sized on-screen window owned by AssistiveControl.
+private func isAccessibilityKeyboardVisible() -> Bool {
+    guard let windows = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID)
+        as? [[String: Any]] else { return false }
+
+    for w in windows {
+        guard windowIsAccessibilityKeyboard(w) else { continue }
+        let alpha = (w[kCGWindowAlpha as String] as? NSNumber)?.doubleValue ?? 1.0
+        if alpha <= 0.01 { continue }
+        guard let boundsDict = w[kCGWindowBounds as String] as? NSDictionary,
+              let bounds = CGRect(dictionaryRepresentation: boundsDict as CFDictionary) else { continue }
+        // The keyboard panel is large; ignore tiny helper/menu windows the process may own.
+        if bounds.width >= 200, bounds.height >= 80 { return true }
+    }
+    return false
+}
+
 // MARK: - Keyboard Hook Manager
 
 class KeyboardHookManager {
@@ -758,8 +826,16 @@ class KeyboardHookManager {
     private var mouseMonitor: Any? // NSEvent monitor for mouse clicks
     private var watchdogTimer: Timer? // periodically re-enables a silently-disabled tap
     private var isRunning = false
+    private var currentTapIsSession = false // which tap level the active hook was created at
 
     private init() {}
+
+    /// Whether the keyboard hook should run at session-tap level: either the user enabled it
+    /// manually, or the Accessibility Keyboard panel is up and needs its synthetic events
+    /// captured (issue #395). The latter is detected live so the tap switches automatically.
+    private var wantsSessionTap: Bool {
+        AppState.shared.sessionTapMode || isAccessibilityKeyboardVisible()
+    }
 
     func start() {
         guard !isRunning else { return }
@@ -777,9 +853,13 @@ class KeyboardHookManager {
             (1 << CGEventType.flagsChanged.rawValue)
 
         // Session tap mode: intercept at cgSessionEventTap level so that synthetic events
-        // injected by remote desktop software (RustDesk, AnyDesk, TeamViewer) are visible.
+        // are visible — keystrokes from the macOS Accessibility Keyboard / on-screen
+        // keyboards (issue #395) and remote desktop software (RustDesk, AnyDesk, TeamViewer),
+        // all of which inject at session level and are invisible to the default HID tap.
         // Default (HID tap): highest priority, physical keystrokes only, best for most cases.
-        let tap: CFMachPort? = if AppState.shared.sessionTapMode {
+        let useSessionTap = wantsSessionTap
+        currentTapIsSession = useSessionTap
+        let tap: CFMachPort? = if useSessionTap {
             CGEvent.tapCreate(tap: .cgSessionEventTap, place: .headInsertEventTap,
                               options: .defaultTap, eventsOfInterest: mask,
                               callback: keyboardCallback, userInfo: nil)
@@ -819,7 +899,15 @@ class KeyboardHookManager {
     private func startWatchdog() {
         watchdogTimer?.invalidate()
         let timer = Timer(timeInterval: 2.0, repeats: true) { [weak self] _ in
-            guard let self, let tap = self.eventTap else { return }
+            guard let self else { return }
+            // Issue #395: switch tap level when the Accessibility Keyboard panel appears or
+            // disappears, so its session-level keystrokes are captured only while it is up.
+            if self.wantsSessionTap != self.currentTapIsSession {
+                Log.info("auto tap-mode: session=\(self.wantsSessionTap) → restart")
+                self.restart()
+                return
+            }
+            guard let tap = self.eventTap else { return }
             if !CGEvent.tapIsEnabled(tap: tap) {
                 CGEvent.tapEnable(tap: tap, enable: true)
                 Log.info("watchdog: event tap was disabled, re-enabled")
@@ -835,6 +923,12 @@ class KeyboardHookManager {
     private func startMouseMonitor() {
         // Monitor both mouseDown and mouseUp to catch clicks and drag-selects
         mouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .leftMouseUp]) { _ in
+            // Issue #395: tapping a key on the macOS Accessibility Keyboard (on-screen
+            // keyboard) is a mouse click on its panel. That panel is non-activating, so the
+            // text cursor never moves — clearing the buffer here would wipe each character
+            // before the next one arrives and Telex/VNI could never compose. Skip the clear
+            // for clicks that land on the keyboard panel itself.
+            if isClickOnAccessibilityKeyboard(NSEvent.mouseLocation) { return }
             RustBridge.clearBufferAll() // Clear everything including word history
             skipWordRestoreAfterClick = true
         }


### PR DESCRIPTION
## Description

Fixes #395 — typing Vietnamese via the macOS Accessibility Keyboard (on-screen keyboard, used on touchscreens) now works.

Two independent issues were blocking it:

1. **Mouse click wiped the buffer.** Each virtual key tap is a left-mouse click on the keyboard panel. The global mouse monitor cleared the composition buffer on every click, so the engine buffer was wiped between every character and Telex/VNI never accumulated enough context to compose (e.g. `u`+`w` → `ư`). Keys reached the engine fine — only the click-clears-buffer logic broke composition. Fix: skip the buffer clear when the click lands on the AssistiveControl panel; it is non-activating, so the text cursor never moves and there is nothing to invalidate.

2. **Synthetic keystrokes were invisible to the event tap.** The panel injects keyDown events at session level, which the default `cghidEventTap` cannot see. Fix: auto-detect when the panel is on screen and transparently switch the tap to `cgSessionEventTap` (and back to HID when it hides), reusing the existing watchdog timer. Users no longer need to enable the manual "remote desktop" toggle.

The panel is identified by its owner bundle id (`com.apple.inputmethod.AssistiveControl`) via the on-screen window list; only owner PID/bounds are read (no window titles), so **no Screen Recording permission is required**.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Manual testing on macOS with the Accessibility Keyboard (System Settings > Accessibility > Keyboard):

- Enabled debug log (`touch /tmp/gonhanh_debug.log`), typed `thuwr gox` on the on-screen keyboard into VSCode/Teams → correctly produced **"thử gõ"**; debug log now shows `K:` replacement entries (previously absent).
- Verified composition still works normally with the physical keyboard.
- Verified the tap auto-switches HID ↔ session as the keyboard panel shows/hides, and reverts to HID-only when the panel is closed.
- Confirmed no behavior change for users who already have the "remote desktop" toggle on.

## Checklist

- [x] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated
