### PR TITLE
fix(macos): prevent dropped characters when typing in Outlook

### DIFF
--- a/platforms/macos/RustBridge.swift
+++ b/platforms/macos/RustBridge.swift
@@ -1547,7 +1547,7 @@ private func detectMethod() -> (InjectionMethod, (UInt32, UInt32, UInt32)) {
     // GoNhanh's synthetic injections (backspace + Vietnamese char) are NOT forwarded,
     // causing garbled input on the remote. Passthrough lets raw keys reach the remote
     // intact; Vietnamese composition must happen on the remote machine itself.
-    let remoteDesktopApps: Set<String> = [
+    let remoteDesktopApps: Set = [
         "com.carriez.rustdesk", // RustDesk
         "com.philandro.anydesk", // AnyDesk
         "com.teamviewer.TeamViewer", // TeamViewer
@@ -1620,6 +1620,7 @@ private func detectMethod() -> (InjectionMethod, (UInt32, UInt32, UInt32)) {
     // Microsoft Office apps - backspace method (selection conflicts with autocomplete)
     if bundleId == "com.microsoft.Excel" { return cached(.slow, (3000, 8000, 3000), "slow:excel") }
     if bundleId == "com.microsoft.Word" { return cached(.slow, (3000, 8000, 3000), "slow:word") }
+    if bundleId == "com.microsoft.Outlook" { return cached(.slow, (8000, 15000, 8000), "slow:outlook") }
 
     // Electron apps - higher delays for Monaco editor
     if bundleId == "com.todesktop.230313mzl4w4u92" { return cached(.slow, (8000, 15000, 8000), "slow:claude") }


### PR DESCRIPTION
## Description

Fixes #396 — typing Vietnamese in Outlook 365 drops characters 100% of the time on macOS 26 (Tahoe).

**Cause:** `com.microsoft.Outlook` matched no app-specific rule in `detectMethod()`, so it fell through to the default `.fast` injection with delays `(1000, 3000, 1500)` µs. "New Outlook" for Mac is a webview app whose contenteditable editor can't keep up with the rapid backspace + retype at those delays, so characters get dropped. The user's debug log confirms every replacement used `method=fast delays=(1000, 3000, 1500)`.

**Fix:** Route Outlook to the `.slow` backspace method with Electron-tier delays `(8000, 15000, 8000)` µs — higher than native Office apps (Word/Excel use `3000/8000/3000`) because Outlook is webview-based, matching how other webview/Electron apps are handled.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `swiftformat --lint platforms/macos` → 0 files require formatting.
- `xcodebuild ... -scheme GoNhanh build` → BUILD SUCCEEDED.
- Verified via the reporter's debug log that Outlook was hitting the default `fast` path; the new rule reassigns it to `slow` with higher delays.

## Checklist

- [x] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated
