### PR TITLE
fix(linux): C++20 build + FFI ImeResult struct-size fix for the Fcitx5 addon

### DIFF
--- a/platforms/linux/CMakeLists.txt
+++ b/platforms/linux/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(fcitx5-gonhanh VERSION 1.0.0 LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find Fcitx5 (Ubuntu package names: Fcitx5Core, Fcitx5Module)

--- a/platforms/linux/selftest.sh
+++ b/platforms/linux/selftest.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# End-to-end self-test for the gonhanh Fcitx5 addon.
+#
+# Spins up a PRIVATE, isolated fcitx5 in its own dbus session with a throwaway
+# config where gonhanh is the only input method, then drives it over DBus
+# (selftest_dbus.py) to verify real telex -> Vietnamese conversion. It never
+# touches the user's live fcitx5 / input session.
+#
+# Prereqs: the addon must be installed (make install-user) so gonhanh.so is in
+# ~/.local/lib/fcitx5 and libgonhanh_core.so in ~/.local/lib. Needs python3-dbus.
+#
+# Usage:  ./selftest.sh          # exit 0 = all telex cases pass, non-zero = fail
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="$HERE/selftest_dbus.py"
+
+USER_ADDON_DIR="$HOME/.local/lib/fcitx5"
+SYS_ADDON_DIR="/usr/lib/x86_64-linux-gnu/fcitx5"
+CORE_LIB="$HOME/.local/lib/libgonhanh_core.so"
+
+if [ ! -f "$USER_ADDON_DIR/gonhanh.so" ]; then
+  echo "FAIL: $USER_ADDON_DIR/gonhanh.so not found — run 'make install-user' first." >&2
+  exit 2
+fi
+if [ ! -f "$CORE_LIB" ]; then
+  echo "FAIL: $CORE_LIB not found — the Rust core is not installed." >&2
+  exit 2
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Throwaway fcitx5 config: single group, gonhanh only.
+mkdir -p "$TMP/fcfg/fcitx5"
+cat > "$TMP/fcfg/fcitx5/profile" <<'EOF'
+[Groups/0]
+Name=Default
+Default Layout=us
+DefaultIM=gonhanh
+
+[Groups/0/Items/0]
+Name=gonhanh
+Layout=
+
+[GroupOrder]
+0=Default
+EOF
+
+export FCITX_ADDON_DIRS="$USER_ADDON_DIR:$SYS_ADDON_DIR"
+export LD_LIBRARY_PATH="$HOME/.local/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+# Run everything inside a private DBus session so the real fcitx5 is untouched.
+LC_ALL=C.UTF-8 dbus-run-session -- bash -c '
+  set -u
+  export XDG_CONFIG_HOME="'"$TMP"'/fcfg"
+  LOG="'"$TMP"'/fcitx5.log"
+  # Disable GUI frontends/UI so it runs headless; only the dbus frontend is needed.
+  fcitx5 --disable=wayland,waylandim,xim,x11,kimpanel,notificationitem,clipboard \
+         -d >"$LOG" 2>&1 &
+  FPID=$!
+  # Wait (max ~10s) for fcitx5 to claim the bus name.
+  for i in $(seq 1 50); do
+    if gdbus call --session --dest org.freedesktop.DBus --object-path /org/freedesktop/DBus \
+         --method org.freedesktop.DBus.NameHasOwner org.fcitx.Fcitx5 2>/dev/null | grep -q true; then
+      break
+    fi
+    sleep 0.2
+  done
+  python3 "'"$PY"'"
+  rc=$?
+  kill "$FPID" 2>/dev/null
+  wait "$FPID" 2>/dev/null
+  exit $rc
+'

--- a/platforms/linux/selftest_dbus.py
+++ b/platforms/linux/selftest_dbus.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+End-to-end self-test for the gonhanh Fcitx5 addon.
+
+Drives the ACTUAL running fcitx5 daemon + gonhanh addon over DBus — no human
+GUI typing. It creates a real input context, activates the `gonhanh` input
+method, injects a telex key sequence via ProcessKeyEvent, and reconstructs the
+resulting on-screen text exactly like a real editor would:
+
+  * a key fcitx does NOT handle (ProcessKeyEvent -> False) is a normal
+    keystroke: the client inserts that character itself;
+  * CommitString appends committed text;
+  * DeleteSurroundingText removes characters (telex corrects a already-typed
+    letter, e.g. "dd" -> delete the 'd', commit "đ");
+  * ForwardKey re-injects a key fcitx generated.
+
+gonhanh commits directly (no preedit), so the visible text is fully determined
+by those signals plus the passthrough keys.
+
+Run it against a fcitx5 where `gonhanh` is the active input method. The
+companion `selftest.sh` spins up a private, isolated fcitx5 for this so it never
+touches the user's live input session. Exit 0 iff every telex case converts to
+the expected Vietnamese, else non-zero with a per-case diff.
+"""
+import sys
+import dbus
+from dbus.mainloop.glib import DBusGMainLoop
+from gi.repository import GLib
+
+SERVICE = "org.fcitx.Fcitx5"
+IM1_PATH = "/org/freedesktop/portal/inputmethod"
+IM1_IFACE = "org.fcitx.Fcitx.InputMethod1"
+IC1_IFACE = "org.fcitx.Fcitx.InputContext1"
+CTRL_PATH = "/controller"
+CTRL_IFACE = "org.fcitx.Fcitx.Controller1"
+
+# key -> (X keysym, X keycode = evdev + 8)
+K = {
+    'd': (0x64, 40), 'a': (0x61, 38), 's': (0x73, 39), 'n': (0x6e, 57),
+    'g': (0x67, 42), 'u': (0x75, 30), 'y': (0x79, 29), 'v': (0x76, 55),
+    'i': (0x69, 31), 'e': (0x65, 26), 't': (0x74, 28), 'o': (0x6f, 32),
+    'w': (0x77, 25), 'r': (0x72, 27), 'j': (0x6a, 44), ' ': (0x20, 65),
+}
+
+# (telex input, expected Vietnamese output)
+CASES = [
+    ("dd",     "đ"),
+    ("aa",     "â"),
+    ("as",     "á"),
+    ("oo",     "ô"),
+    ("ow",     "ơ"),
+    ("ddaay",  "đây"),
+    ("ddungs", "đúng"),
+    ("vieejt", "việt"),
+    ("tieengs", "tiếng"),
+]
+
+
+def main():
+    DBusGMainLoop(set_as_default=True)
+    bus = dbus.SessionBus()
+
+    ctx = GLib.MainContext.default()
+
+    def pump(ms):
+        deadline = GLib.get_monotonic_time() + ms * 1000
+        while GLib.get_monotonic_time() < deadline:
+            while ctx.pending():
+                ctx.iteration(False)
+            GLib.usleep(1500)
+
+    ctrl = dbus.Interface(bus.get_object(SERVICE, CTRL_PATH), CTRL_IFACE)
+    avail = [str(x[0]) for x in ctrl.AvailableInputMethods()]
+    if "gonhanh" not in avail:
+        print("FAIL: gonhanh not loaded (not in AvailableInputMethods).")
+        print("      addon .so missing from fcitx5's addon dir, or it failed to dlopen.")
+        return 3
+
+    im1 = dbus.Interface(bus.get_object(SERVICE, IM1_PATH), IM1_IFACE)
+    path, _uuid = im1.CreateInputContext([("program", "gonhanh-selftest")])
+    ic = dbus.Interface(bus.get_object(SERVICE, path), IC1_IFACE)
+
+    buf = {"s": ""}
+    cur_im = {"name": None}
+
+    def on_commit(s):
+        buf["s"] += str(s)
+
+    def on_delete(offset, size):
+        n = int(size)
+        if n > 0:
+            buf["s"] = buf["s"][:-n] if n <= len(buf["s"]) else ""
+
+    def on_forward(keyval, state, is_release):
+        kv = int(keyval)
+        if not bool(is_release) and 0x20 <= kv < 0x7f:
+            buf["s"] += chr(kv)
+
+    def on_curim(name, unique, lang):
+        cur_im["name"] = str(unique)
+
+    m = bus.add_signal_receiver
+    m(on_commit,  signal_name="CommitString",          dbus_interface=IC1_IFACE, path=path)
+    m(on_delete,  signal_name="DeleteSurroundingText",  dbus_interface=IC1_IFACE, path=path)
+    m(on_forward, signal_name="ForwardKey",             dbus_interface=IC1_IFACE, path=path)
+    m(on_curim,   signal_name="CurrentIM",              dbus_interface=IC1_IFACE, path=path)
+
+    ic.SetCapability(dbus.UInt64(0))
+    ic.FocusIn()
+    pump(200)
+    ctrl.Activate()
+    pump(120)
+    ctrl.SetCurrentIM("gonhanh")
+    pump(200)
+
+    active = cur_im["name"] or str(ctrl.CurrentInputMethod())
+    if active != "gonhanh":
+        print(f"FAIL: could not activate gonhanh for the test context (active IM = {active!r}).")
+        return 4
+
+    t = 1
+    results = []
+    for text_in, expected in CASES:
+        ic.Reset()
+        pump(40)
+        buf["s"] = ""
+        for ch in text_in:
+            keyval, keycode = K[ch]
+            handled = ic.ProcessKeyEvent(keyval, keycode, 0, False, t); t += 1
+            pump(35)
+            # A key fcitx did not consume is typed by the client itself.
+            if not bool(handled) and 0x20 <= keyval < 0x7f:
+                buf["s"] += chr(keyval)
+            ic.ProcessKeyEvent(keyval, keycode, 0, True, t); t += 1
+            pump(12)
+        pump(50)
+        got = buf["s"]
+        results.append((text_in, expected, got, got == expected))
+
+    try:
+        ic.FocusOut()
+        ic.DestroyIC()
+    except Exception:
+        pass
+
+    print("=== gonhanh telex E2E selftest (live fcitx5 over DBus) ===")
+    allok = True
+    for text_in, expected, got, ok in results:
+        allok = allok and ok
+        print(f"  [{'PASS' if ok else 'FAIL'}] {text_in!r:12} -> {got!r:10} (expected {expected!r})")
+    print("=== %s ===" % ("ALL PASS" if allok else "FAILURES PRESENT"))
+    return 0 if allok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/platforms/linux/src/RustBridge.cpp
+++ b/platforms/linux/src/RustBridge.cpp
@@ -30,8 +30,8 @@ std::pair<int, std::string> RustBridge::processKey(
     if (result->action == static_cast<uint8_t>(ImeAction::Send)) {
         output.first = result->backspace;
 
-        // Convert UTF-32 chars to UTF-8 string
-        for (uint8_t i = 0; i < result->count && i < 32; ++i) {
+        // Convert UTF-32 chars to UTF-8 string (count ≤ 255, chars[] holds 256)
+        for (int i = 0; i < result->count; ++i) {
             if (result->chars[i] > 0) {
                 output.second += codePointToUtf8(result->chars[i]);
             }

--- a/platforms/linux/src/RustBridge.h
+++ b/platforms/linux/src/RustBridge.h
@@ -8,26 +8,29 @@
 // FFI Result structure - must match core/src/engine/mod.rs
 // #[repr(C)]
 // pub struct Result {
-//     pub chars: [u32; 32],
+//     pub chars: [u32; MAX],   // MAX = 256
 //     pub action: u8,
 //     pub backspace: u8,
 //     pub count: u8,
-//     pub _pad: u8,
+//     pub flags: u8,
 // }
 //
 // Note: Rust #[repr(C)] uses C ABI layout, which matches C++ struct layout
-// for this specific arrangement. The array (128 bytes) is followed by
-// 4 bytes of u8 fields = 132 bytes total with no implicit padding needed.
+// for this arrangement. The array (256 * 4 = 1024 bytes) is followed by
+// 4 bytes of u8 fields = 1028 bytes total with no implicit padding needed.
 struct ImeResult {
-    uint32_t chars[32];  // 128 bytes
+    uint32_t chars[256]; // 1024 bytes — MUST match Rust `MAX` in core/src/engine/mod.rs
     uint8_t action;      // 1 byte
     uint8_t backspace;   // 1 byte
     uint8_t count;       // 1 byte
-    uint8_t _pad;        // 1 byte (explicit padding to 4-byte boundary)
+    uint8_t flags;       // 1 byte (bit0 = key_consumed)
 };
 
-// Verify struct size matches Rust at compile time
-static_assert(sizeof(ImeResult) == 132, "ImeResult size mismatch with Rust core");
+// Verify struct size matches Rust at compile time.
+// Rust `Result` uses chars: [u32; 256] (MAX=256) → 1024 + 4 = 1028 bytes.
+// (Was 132 with chars[32] — that misplaced `action` at offset 128 vs Rust's 1024,
+//  so the addon always read action=0 and passed every key through untransformed.)
+static_assert(sizeof(ImeResult) == 1028, "ImeResult size mismatch with Rust core");
 
 // Action types
 enum class ImeAction : uint8_t {


### PR DESCRIPTION
## Mô tả

Sửa để bộ gõ chạy đúng trên **Linux / Fcitx5** (test trên **Ubuntu**). Trước đó addon Linux gõ telex **không biến đổi ký tự** — gõ `dd` ra `dd` thay vì `đ`.

Gồm 2 fix + 1 test, **chỉ đụng `platforms/linux/`** (không thay đổi Rust core hay macOS):

1. **Build C++20** — `platforms/linux/CMakeLists.txt`
   Fcitx5 5.1.19 dùng `std::source_location` + `consteval` trong macro log (`FCITX_*LOG*`) → cần **C++20**; addon đang để C++17 nên không build được. Bump `CMAKE_CXX_STANDARD 17 → 20`.

2. **FFI struct-size mismatch** — `platforms/linux/src/RustBridge.{h,cpp}`
   Rust core khai `ImeResult.chars: [u32; 256]` (struct **1028 byte**, field `action` ở **offset 1024**), nhưng phía C++ khai `chars[32]` (**132 byte**, đọc `action` ở **offset 128**) → luôn đọc `action = 0` → **mọi phím bị passthrough**, không convert. Sửa `chars[32] → [256]`, `static_assert(132 → 1028)`, và bỏ giới hạn `i < 32` trong vòng copy UTF-8. `static_assert` cũ chỉ kiểm tra kích thước phía C++ nên mismatch bị "im lặng".

3. **E2E selftest** — `platforms/linux/selftest.sh` + `selftest_dbus.py`
   Dựng một fcitx5 **cô lập** qua DBus, bơm chuỗi phím telex bằng `ProcessKeyEvent`, dựng lại text từ `CommitString`/`DeleteSurroundingText` rồi assert. Đây là guard bắt **đúng loại lỗi ABI** ở (2) — test FFI thuần (chỉ gọi hàm) không bắt được.

## Loại thay đổi
- [x] 🐛 Sửa lỗi

## Testing

Test trên **Ubuntu** (Fcitx5 5.1.19). Build lại trên nhánh `main` mới nhất của repo gốc → **build OK**, chạy `platforms/linux/selftest.sh`:

```
=== gonhanh telex E2E selftest (live fcitx5 over DBus) ===
  [PASS] 'dd'      -> 'đ'
  [PASS] 'aa'      -> 'â'
  [PASS] 'as'      -> 'á'
  [PASS] 'oo'      -> 'ô'
  [PASS] 'ow'      -> 'ơ'
  [PASS] 'ddaay'   -> 'đây'
  [PASS] 'ddungs'  -> 'đúng'
  [PASS] 'vieejt'  -> 'việt'
  [PASS] 'tieengs' -> 'tiếng'
=== ALL PASS ===
```

## Checklist
- [x] Đã test end-to-end trên Ubuntu (selftest **9/9 PASS**)
- [x] Không đụng Rust core → `cargo test` / `cargo fmt` / `cargo clippy` không bị ảnh hưởng (chỉ sửa C++ Linux port)
- [ ] CHANGELOG.md — repo hiện chưa có file này nên bỏ qua; maintainer bổ sung nếu cần

---
> Đóng góp từ môi trường **Linux (Ubuntu)** — mình dùng bộ gõ này với fcitx5 hằng ngày. Nếu maintainer muốn tách nhỏ commit hay chỉnh thêm, mình sẵn sàng.
