### PR TITLE
fix: broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Nếu các bạn thấy phần mềm hữu ích có thể [ủng hộ tôi tại
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=khaphanspace/gonhanh.org&type=Timeline&legend=bottom-right)](https://www.star-history.com/#khaphanspace/gonhanh.org&type=Timeline&legend=bottom-right)
+[![Star History Chart](https://star-history.dera.page/svg?repos=khaphanspace/gonhanh.org&type=Timeline&legend=bottom-right)](https://star-history.dera.page/#khaphanspace/gonhanh.org&type=Timeline&legend=bottom-right)
 
 ---
 


### PR DESCRIPTION
The star history chart was not rendering because of GitHub stargazer API restrictions. This change points it to a working source so the chart displays correctly again.