### PR TITLE
fix(macos): use emptyCharPrefix injection for Helium browser address bar

### DIFF
--- a/platforms/macos/RustBridge.swift
+++ b/platforms/macos/RustBridge.swift
@@ -1860,6 +1860,7 @@ private func detectMethod() -> (InjectionMethod, (UInt32, UInt32, UInt32)) {
         "com.vivaldi.Vivaldi", // Vivaldi
         "com.vivaldi.Vivaldi.snapshot", // Vivaldi Snapshot
         "ru.yandex.desktop.yandex-browser", // Yandex Browser
+        "net.imput.helium", // Helium
         // Opera
         "com.opera.Opera", // Opera
         "com.operasoftware.Opera", // Opera (alt)


### PR DESCRIPTION
## Description

Gõ `tại` trên address bar của trình duyệt Helium ra `taại` do thiếu một backspace. Thêm Helium vào danh sách browser dùng phương thức inject `emptyCharPrefix`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Root Cause

Helium (`net.imput.helium`, Chromium-based) chưa có trong danh sách `browsers` của `detectMethod()` nên rơi vào phương thức inject mặc định `fast` (log: `inject: bs=2 text='ại' method=fast`). Omnibox của Chromium tự highlight suggestion autocomplete; backspace đầu tiên chỉ xóa phần highlight thay vì ký tự đã gõ, nên chỉ 1 trong 2 backspace có tác dụng → `ta` + `ại` = `taại`. Các browser Chromium khác (Chrome, Brave, Edge…) không bị vì đã nằm trong danh sách và dùng `emptyCharPrefix` để phá autocomplete trước khi xóa.

## Fix

Thêm bundle ID `net.imput.helium` vào nhóm Chromium-based trong mảng `browsers`. Helium từ đó dùng `emptyCharPrefix` với delays (3000, 8000, 3000) giống Chrome/Brave — cùng cơ chế đã được kiểm chứng với các trình duyệt Chromium khác, không cần logic mới.

**Changed file(s):** `platforms/macos/RustBridge.swift` (`detectMethod()` → mảng `browsers`)

## Testing

1. Build và chạy GoNhanh, chọn kiểu gõ Telex.
2. Mở Helium, click vào address bar.
3. Gõ nhanh `t` `a` `j` `i` `<space>` `s` `a` `o`.
4. Kết quả phải là `tại sao` (trước fix: `taại sao`).
5. Bật debug log, xác nhận dòng inject hiển thị `method=emptyCharPrefix` thay vì `method=fast`.
6. Kiểm tra hồi quy: gõ thử trong ô nhập text của một trang web (vd. Google search box) trên Helium để đảm bảo web content vẫn gõ bình thường.

## Checklist

- [ ] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated

Fixes #418
