### PR TITLE
feat(macos): add optional secondary shortcut to toggle the engine

### DIFF
--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -414,6 +414,12 @@ NotificationCenter.default.post(name: .toggleVietnamese, object: nil)
 return nil
 ```
 
+The toggle hotkey is user-configurable (`KeyboardShortcut` in `AppMetadata.swift`). An optional
+**secondary toggle shortcut** (default Ctrl+Shift+Space, off by default) can be enabled in Settings so
+an external keyboard without an `fn` key can still toggle the engine when the primary shortcut is
+`fn`-only. Both are matched in the keyboard callback (`matchesToggleShortcut` /
+`matchesModifierOnlyShortcut` in `RustBridge.swift`); the secondary is `nil` while disabled.
+
 ## Component Interactions
 
 ### Initialization Sequence

--- a/platforms/macos/AppMetadata.swift
+++ b/platforms/macos/AppMetadata.swift
@@ -80,6 +80,8 @@ enum SettingsKey {
     static let bracketShortcut = "gonhanh.bracketShortcut"
     static let restoreShortcutEnabled = "gonhanh.escRestore" // Keep old key for backward compat
     static let restoreShortcut = "gonhanh.shortcut.restore"
+    static let secondaryToggleShortcut = "gonhanh.shortcut.toggleSecondary"
+    static let secondaryToggleShortcutEnabled = "gonhanh.shortcut.toggleSecondaryEnabled"
     static let modernTone = "gonhanh.modernTone"
     static let englishAutoRestore = "gonhanh.englishAutoRestore"
     static let autoCapitalize = "gonhanh.autoCapitalize"
@@ -105,6 +107,9 @@ struct KeyboardShortcut: Codable, Equatable {
 
     // Default: ESC (for restore diacritics)
     static let defaultRestore = KeyboardShortcut(keyCode: 0x35, modifiers: 0)
+
+    // Default: Ctrl+Shift+Space (secondary toggle, for external keyboards without fn)
+    static let defaultSecondaryToggle = KeyboardShortcut(keyCode: 0x31, modifiers: CGEventFlags([.maskControl, .maskShift]).rawValue)
 
     var displayParts: [String] {
         var parts: [String] = []
@@ -198,6 +203,28 @@ struct KeyboardShortcut: Codable, Equatable {
         if let data = try? JSONEncoder().encode(self) {
             UserDefaults.standard.set(data, forKey: SettingsKey.restoreShortcut)
         }
+    }
+
+    static func loadSecondaryToggle() -> KeyboardShortcut {
+        guard let data = UserDefaults.standard.data(forKey: SettingsKey.secondaryToggleShortcut),
+              let shortcut = try? JSONDecoder().decode(KeyboardShortcut.self, from: data)
+        else {
+            return .defaultSecondaryToggle
+        }
+        return shortcut
+    }
+
+    func saveAsSecondaryToggle() {
+        if let data = try? JSONEncoder().encode(self) {
+            UserDefaults.standard.set(data, forKey: SettingsKey.secondaryToggleShortcut)
+        }
+    }
+
+    /// Secondary toggle shortcut, or nil when the user has not enabled it.
+    /// Lets an external keyboard without an fn key still toggle the engine (issue #416).
+    static func activeSecondaryToggle() -> KeyboardShortcut? {
+        guard UserDefaults.standard.bool(forKey: SettingsKey.secondaryToggleShortcutEnabled) else { return nil }
+        return loadSecondaryToggle()
     }
 
     /// Check if this shortcut is modifier-only (no character key)

--- a/platforms/macos/MainSettingsView.swift
+++ b/platforms/macos/MainSettingsView.swift
@@ -184,6 +184,20 @@ class AppState: ObservableObject {
         }
     }
 
+    @Published var secondaryToggleShortcut: KeyboardShortcut {
+        didSet {
+            secondaryToggleShortcut.saveAsSecondaryToggle()
+            NotificationCenter.default.post(name: .secondaryShortcutChanged, object: nil)
+        }
+    }
+
+    @Published var secondaryToggleShortcutEnabled: Bool = false {
+        didSet {
+            UserDefaults.standard.set(secondaryToggleShortcutEnabled, forKey: SettingsKey.secondaryToggleShortcutEnabled)
+            NotificationCenter.default.post(name: .secondaryShortcutChanged, object: nil)
+        }
+    }
+
     @Published var advancedMode: Bool = false {
         didSet {
             UserDefaults.standard.set(advancedMode, forKey: SettingsKey.advancedMode)
@@ -246,6 +260,8 @@ class AppState: ObservableObject {
         currentMethod = InputMode(rawValue: defaults.integer(forKey: SettingsKey.method)) ?? .telex
         toggleShortcut = KeyboardShortcut.load()
         restoreShortcut = KeyboardShortcut.loadRestoreShortcut()
+        secondaryToggleShortcut = KeyboardShortcut.loadSecondaryToggle()
+        secondaryToggleShortcutEnabled = defaults.bool(forKey: SettingsKey.secondaryToggleShortcutEnabled)
         perAppModeEnabled = defaults.bool(forKey: SettingsKey.perAppMode)
         autoWShortcut = defaults.bool(forKey: SettingsKey.autoWShortcut)
         bracketShortcut = defaults.bool(forKey: SettingsKey.bracketShortcut)
@@ -672,6 +688,8 @@ struct KeyCap: View {
         Text(displayText)
             .font(.system(size: 11, weight: .medium))
             .foregroundColor(Color(NSColor.secondaryLabelColor))
+            .lineLimit(1)
+            .fixedSize() // Keep "⌃ control" on one line even when the row is width-constrained
             .padding(.horizontal, 6)
             .padding(.vertical, 3)
             .background(RoundedRectangle(cornerRadius: 4).fill(Color(NSColor.controlBackgroundColor).opacity(0.8)))
@@ -958,6 +976,7 @@ struct NavButton: View {
 struct SettingsPageView: View {
     @ObservedObject var appState: AppState
     @State private var isRecordingShortcut = false
+    @State private var isRecordingSecondaryShortcut = false
     @State private var isRecordingRestoreShortcut = false
     @State private var showShortcutsSheet = false
 
@@ -1007,6 +1026,13 @@ struct SettingsPageView: View {
             VStack(spacing: 0) {
                 ShortcutRecorderRow(shortcut: $appState.toggleShortcut,
                                     isRecording: $isRecordingShortcut)
+                Divider().padding(.leading, 12)
+                ShortcutRecorderRow(shortcut: $appState.secondaryToggleShortcut,
+                                    isRecording: $isRecordingSecondaryShortcut,
+                                    title: "Phím tắt bật/tắt thứ hai",
+                                    subtitle: "Khi bàn phím rời không có fn",
+                                    isEnabled: $appState.secondaryToggleShortcutEnabled,
+                                    duplicateOf: appState.toggleShortcut)
                 Divider().padding(.leading, 12)
                 RestoreShortcutRecorderRow(
                     shortcut: $appState.restoreShortcut,
@@ -1424,33 +1450,56 @@ private let systemShortcuts: Set<String> = [
 struct ShortcutRecorderRow: View {
     @Binding var shortcut: KeyboardShortcut
     @Binding var isRecording: Bool
+    var title = "Bật/tắt bộ gõ"
+    var subtitle = "Nhấn để thay đổi"
+    /// When provided, shows an on/off switch and blocks recording while off.
+    var isEnabled: Binding<Bool>?
+    /// Another shortcut this one must not equal (e.g. the primary toggle for the secondary row).
+    var duplicateOf: KeyboardShortcut?
     @State private var hovered = false
     @State private var recordedObserver: NSObjectProtocol?
     @State private var cancelledObserver: NSObjectProtocol?
     @State private var windowObserver: NSObjectProtocol?
 
-    private var hasConflict: Bool {
-        systemShortcuts.contains(shortcut.displayParts.joined())
+    private var enabled: Bool { isEnabled?.wrappedValue ?? true }
+
+    private var conflictMessage: String? {
+        if let other = duplicateOf, other == shortcut { return "Trùng với phím tắt bật/tắt chính" }
+        if systemShortcuts.contains(shortcut.displayParts.joined()) { return "Phím tắt này có thể xung đột với hệ thống" }
+        return nil
     }
 
     var body: some View {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
-                Text("Bật/tắt bộ gõ").font(.system(size: 13))
-                Text("Nhấn để thay đổi")
+                Text(title).font(.system(size: 13))
+                Text(subtitle)
                     .font(.system(size: 11))
                     .foregroundColor(Color(NSColor.secondaryLabelColor))
             }
             Spacer()
-            shortcutDisplay
+            HStack(spacing: 8) {
+                shortcutDisplay
+                if let isEnabled {
+                    Toggle("", isOn: isEnabled)
+                        .toggleStyle(.switch)
+                        .labelsHidden()
+                }
+            }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
         .background((hovered || isRecording) ? Color(NSColor.controlBackgroundColor).opacity(0.3) : .clear)
         .contentShape(Rectangle())
-        .onHover { hovered = $0 }
-        .onTapGesture { isRecording ? stopRecording() : startRecording() }
+        .onHover { hovered = enabled && $0 }
+        .onTapGesture {
+            guard enabled else { return }
+            isRecording ? stopRecording() : startRecording()
+        }
         .onDisappear { stopRecording() }
+        .onChange(of: enabled) { _ in
+            if isRecording { stopRecording() }
+        }
     }
 
     private var shortcutDisplay: some View {
@@ -1464,14 +1513,15 @@ struct ShortcutRecorderRow: View {
                     .background(RoundedRectangle(cornerRadius: 4).stroke(Color.accentColor, lineWidth: 1))
             } else {
                 ForEach(shortcut.displayParts, id: \.self) { KeyCap(text: $0) }
-                if hasConflict {
+                if let conflictMessage {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .font(.system(size: 12))
                         .foregroundColor(.orange)
-                        .help("Phím tắt này có thể xung đột với hệ thống")
+                        .help(conflictMessage)
                 }
             }
         }
+        .opacity(enabled ? 1.0 : 0.5)
     }
 
     private func startRecording() {

--- a/platforms/macos/RustBridge.swift
+++ b/platforms/macos/RustBridge.swift
@@ -1045,6 +1045,7 @@ class KeyboardHookManager {
         // Remove notification observers to prevent leak across restart() cycles
         if let obs = shortcutObserver { NotificationCenter.default.removeObserver(obs); shortcutObserver = nil }
         if let obs = restoreShortcutObserver { NotificationCenter.default.removeObserver(obs); restoreShortcutObserver = nil }
+        if let obs = secondaryShortcutObserver { NotificationCenter.default.removeObserver(obs); secondaryShortcutObserver = nil }
         eventTap = nil
         runLoopSource = nil
         mouseMonitor = nil
@@ -1122,11 +1123,13 @@ private let kModifierMask: CGEventFlags = [.maskSecondaryFn, .maskControl, .mask
 private var modifierChord = ModifierChordTracker()
 private var currentShortcut = KeyboardShortcut.load()
 private var currentRestoreShortcut = KeyboardShortcut.loadRestoreShortcut()
+private var currentSecondaryShortcut = KeyboardShortcut.activeSecondaryToggle() // nil when disabled
 private var isRecordingShortcut = false
 private var recordingModifiers: CGEventFlags = [] // Current modifiers being held
 private var peakRecordingModifiers: CGEventFlags = [] // Peak modifiers during recording
 private var shortcutObserver: NSObjectProtocol?
 private var restoreShortcutObserver: NSObjectProtocol?
+private var secondaryShortcutObserver: NSObjectProtocol?
 /// Skip word restore after mouse click (user may be selecting/deleting text)
 /// Reset to false after first keystroke
 private var skipWordRestoreAfterClick = false
@@ -1269,10 +1272,15 @@ func setupShortcutObserver() {
     restoreShortcutObserver = NotificationCenter.default.addObserver(forName: .restoreShortcutChanged, object: nil, queue: .main) { _ in
         currentRestoreShortcut = KeyboardShortcut.loadRestoreShortcut()
     }
+    secondaryShortcutObserver = NotificationCenter.default.addObserver(forName: .secondaryShortcutChanged, object: nil, queue: .main) { _ in
+        currentSecondaryShortcut = KeyboardShortcut.activeSecondaryToggle()
+    }
 }
 
+/// Either the primary or the (optional) secondary toggle shortcut fires the toggle.
 private func matchesToggleShortcut(keyCode: UInt16, flags: CGEventFlags) -> Bool {
     currentShortcut.matches(keyCode: keyCode, flags: flags)
+        || currentSecondaryShortcut?.matches(keyCode: keyCode, flags: flags) == true
 }
 
 private func matchesRestoreShortcut(keyCode: UInt16, flags: CGEventFlags) -> Bool {
@@ -1286,6 +1294,7 @@ private func matchesRestoreShortcut(keyCode: UInt16, flags: CGEventFlags) -> Boo
 
 private func matchesModifierOnlyShortcut(flags: CGEventFlags) -> Bool {
     currentShortcut.matchesModifierOnly(flags: flags)
+        || currentSecondaryShortcut?.matchesModifierOnly(flags: flags) == true
 }
 
 /// Trigger restore shortcut - restore raw ASCII and clear buffer
@@ -2235,6 +2244,7 @@ extension Notification.Name {
     static let toggleVietnamese = Notification.Name("toggleVietnamese")
     static let shortcutChanged = Notification.Name("shortcutChanged")
     static let restoreShortcutChanged = Notification.Name("restoreShortcutChanged")
+    static let secondaryShortcutChanged = Notification.Name("secondaryShortcutChanged")
     static let shortcutRecorded = Notification.Name("shortcutRecorded")
     static let shortcutRecordingCancelled = Notification.Name("shortcutRecordingCancelled")
 }

--- a/platforms/macos/Tests/KeyboardShortcutTests.swift
+++ b/platforms/macos/Tests/KeyboardShortcutTests.swift
@@ -6,7 +6,32 @@ import XCTest
 final class KeyboardShortcutTests: XCTestCase {
     override func tearDown() {
         UserDefaults.standard.removeObject(forKey: SettingsKey.toggleShortcut)
+        UserDefaults.standard.removeObject(forKey: SettingsKey.secondaryToggleShortcut)
+        UserDefaults.standard.removeObject(forKey: SettingsKey.secondaryToggleShortcutEnabled)
         super.tearDown()
+    }
+
+    // MARK: - Secondary Toggle Shortcut
+
+    func testSecondaryToggleDefaultDiffersFromPrimary() {
+        XCTAssertNotEqual(KeyboardShortcut.defaultSecondaryToggle, KeyboardShortcut.default)
+        XCTAssertEqual(KeyboardShortcut.loadSecondaryToggle(), .defaultSecondaryToggle)
+    }
+
+    func testSecondaryToggleSaveAndLoadIsIndependentOfPrimary() {
+        let secondary = KeyboardShortcut(keyCode: 0x00, modifiers: CGEventFlags([.maskCommand, .maskAlternate]).rawValue)
+        secondary.saveAsSecondaryToggle()
+
+        XCTAssertEqual(KeyboardShortcut.loadSecondaryToggle(), secondary)
+        XCTAssertEqual(KeyboardShortcut.load(), .default)
+    }
+
+    func testActiveSecondaryToggleIsNilUntilEnabled() {
+        KeyboardShortcut.defaultSecondaryToggle.saveAsSecondaryToggle()
+        XCTAssertNil(KeyboardShortcut.activeSecondaryToggle())
+
+        UserDefaults.standard.set(true, forKey: SettingsKey.secondaryToggleShortcutEnabled)
+        XCTAssertEqual(KeyboardShortcut.activeSecondaryToggle(), .defaultSecondaryToggle)
     }
 
     // MARK: - Default Shortcut


### PR DESCRIPTION
## Description

Thêm phím tắt bật/tắt bộ gõ thứ hai (tùy chọn, mặc định tắt) để người gán `fn` trên MacBook vẫn bật/tắt được khi dùng bàn phím rời không có `fn`.

## Type of Change

- [x] New feature

## Root Cause

App chỉ có một phím tắt bật/tắt; callback chỉ so khớp với `currentShortcut` duy nhất. Gán `fn` thì bàn phím PC không còn cách nào bật/tắt.

## Fix

- `KeyboardShortcut`: thêm secondary toggle (mặc định Ctrl+Shift+Space), `activeSecondaryToggle()` trả `nil` khi chưa bật → không đổi hành vi người dùng cũ.
- `RustBridge`: `matchesToggleShortcut` / `matchesModifierOnlyShortcut` OR thêm phím phụ; observer riêng, có teardown.
- UI: hàng "Phím tắt bật/tắt thứ hai" tái dùng `ShortcutRecorderRow` với switch on/off, cảnh báo khi trùng phím chính. `KeyCap` khóa một dòng.

**Changed file(s):** `AppMetadata.swift`, `MainSettingsView.swift`, `RustBridge.swift`, `Tests/KeyboardShortcutTests.swift`, `docs/system-architecture.md`

## Testing

- Unit: 3 test mới trong `KeyboardShortcutTests` pass.
- Thủ công: gán phím chính = `fn` → bật switch, ghi `Ctrl+Shift+Space` → cả hai đều đổi trạng thái; tắt switch → phím phụ hết tác dụng ngay; ghi trùng phím chính → hiện cảnh báo.

## Checklist

- [x] Tests pass
- [x] Documentation updated
- [ ] CHANGELOG.md updated

Fixes #416
