### PR TITLE
fix(macos): inject char-by-char in Adobe apps

### DIFF
--- a/platforms/macos/RustBridge.swift
+++ b/platforms/macos/RustBridge.swift
@@ -1916,6 +1916,10 @@ private func detectMethod() -> (InjectionMethod, (UInt32, UInt32, UInt32)) {
     // Foxit PDF Reader - char-by-char for reliable Vietnamese input in form fields
     if bundleId == "com.foxit-software.Foxit.PDF.Reader" { return cached(.charByChar, (0, 0, 0), "char:foxit") }
 
+    // Adobe apps (Illustrator, InDesign, Photoshop, ...) use a custom text engine that only
+    // reads the first character of a multi-character key event, so chunked text is truncated.
+    if bundleId.hasPrefix("com.adobe.") { return cached(.charByChar, (3000, 8000, 3000), "char:adobe") }
+
     // Games - synchronous proxy injection (Issue #264: Vietnamese typing in LOL)
     if bundleId.hasPrefix("com.riotgames") { return cached(.syncProxy, (0, 0, 0), "sync:game") }
 


### PR DESCRIPTION
## Description

Illustrator/InDesign nuốt chữ khi gõ dấu (`hoạt động tình nguyện` → `hoạ đ tì nguyê`). Chuyển mọi app `com.adobe.*` sang phương thức inject `charByChar`.

## Type of Change

- [x] Bug fix

## Root Cause

Log cho thấy engine phát đúng (`bs=2 'ạt'`, `bs=3 'ộng'`…) nhưng app chỉ giữ ký tự đầu mỗi chuỗi. Method mặc định `fast` gửi text theo chunk 20 ký tự trong một CGEvent (`chunks=1`); text engine riêng của Adobe chỉ đọc 1 ký tự từ mỗi key event nên phần còn lại bị bỏ. Chưa có rule nào cho Adobe trong `detectMethod()`.

## Fix

Thêm `bundleId.hasPrefix("com.adobe.")` → `charByChar` (1 ký tự/event) với delays trung bình như Safari, cùng cách đã dùng cho Foxit/TeXstudio/Caudex. Prefix bao phủ cả Photoshop, Premiere, After Effects vốn dùng chung text engine.

**Changed file(s):** `platforms/macos/RustBridge.swift` (`detectMethod()`)

## Testing

1. Mở Illustrator hoặc InDesign, tạo text box, kiểu gõ VNI.
2. Gõ nhanh `hoạt động tình nguyện` → phải ra đúng, không mất chữ.
3. Debug log: dòng inject hiển thị `method=charByChar`, `chunks` = số ký tự.
4. Chưa kiểm chứng thực tế (không có app). Reporter có thể xác nhận sớm bằng workaround: Settings → Per-app → Illustrator → Injection = Char by char.

## Checklist

- [x] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated

Fixes #413
