### PR TITLE
fix(core): always allow k before a/o/u for proper nouns

### DIFF
--- a/core/src/data/constants.rs
+++ b/core/src/data/constants.rs
@@ -162,8 +162,8 @@ pub const V2_CIRCUMFLEX_REQUIRED: &[[u16; 2]] = &[
 pub const SPELLING_RULES: &[(&[u16], &[u16], &str)] = &[
     // c before e, i, y → invalid (should use k)
     (&[keys::C], &[keys::E, keys::I, keys::Y], "c before e/i/y"),
-    // k before a, o, u → invalid (should use c)
-    (&[keys::K], &[keys::A, keys::O, keys::U], "k before a/o/u"),
+    // k before a/o/u is intentionally NOT rejected: proper nouns and loanwords
+    // (Bắc Kạn, Hồng Kông, kăng) need diacritics even though standard spelling uses c.
     // g before e → invalid (should use gh)
     (&[keys::G], &[keys::E], "g before e"),
     // ng before e, i → invalid (should use ngh)

--- a/core/src/engine/validation.rs
+++ b/core/src/engine/validation.rs
@@ -550,7 +550,7 @@ mod tests {
     const INVALID_INITIAL: &[&str] = &["clau", "john", "bla", "string", "chrome"];
 
     /// Invalid: spelling violations
-    const INVALID_SPELLING: &[&str] = &["ci", "ce", "cy", "ka", "ko", "ku", "ngi", "nge", "ge"];
+    const INVALID_SPELLING: &[&str] = &["ci", "ce", "cy", "ngi", "nge", "ge"];
 
     /// Invalid: foreign words
     const INVALID_FOREIGN: &[&str] = &["exp", "expect", "test", "claudeco", "claus", "gues"];

--- a/core/tests/data/english_100k_failures.txt
+++ b/core/tests/data/english_100k_failures.txt
@@ -1,6 +1,6 @@
 # English 100k Typing Variants Failures
 # Format: WORD \t VARIANT \t EXPECTED \t ACTUAL \t BUFFER
-# Total failures: 395
+# Total failures: 371
 
 been	been	been	bên	bên
 see	see	see	sê	sê
@@ -51,7 +51,6 @@ boost	boost	boost	bốt	bôst
 oo	oo	oo	ô	ô
 teen	teen	teen	tên	tên
 eec	eec	eec	êc	êc
-kuwait	kuwwait	kuwait	kuwwait	kưwait
 downs	downs	downs	dớn	dơns
 ee	ee	ee	ê	ê
 dow	dow	dow	dơ	dơ
@@ -140,12 +139,10 @@ moo	moo	moo	mô	mô
 ghee	ghee	ghee	ghê	ghê
 caa	caa	caa	câ	câ
 iaa	iaa	iaa	iâ	iâ
-kuwaiti	kuwwaiti	kuwaiti	kuwwaiti	kưwaiti
 ooze	ooze	ooze	oe	ôze
 sawn	sawn	sawn	săn	săn
 pawns	pawns	pawns	pắn	păns
 cee	ceee	cee	ceee	cêe
-kawasaki	kawwasaki	kawasaki	kawwasaki	kăwasaki
 chee	chee	chee	chê	chê
 yee	yee	yee	yê	yê
 naa	naa	naa	nâ	nâ
@@ -166,11 +163,9 @@ dawns	dawns	dawns	dắn	dăns
 cocoons	cocoons	cocoons	cocons	cocôns
 dowd	dowd	dowd	đơ	dơd
 roo	roo	roo	rô	rô
-koo	kooo	koo	kooo	kôo
+koo	koo	koo	kô	kô
 aad	aad	aad	âd	âd
 dde	dde	dde	đe	đe
-kowloon	kowwloon	kowloon	kowwloon	kơwlôn
-kowalski	kowwalski	kowalski	kowwalski	kơwalski
 swoon	swoon	swoon	suôn	swôn
 maa	maa	maa	mâ	mâ
 paa	paa	paa	pâ	pâ
@@ -199,7 +194,6 @@ dds	dds	dds	đs	đs
 ees	ees	ees	ế	ês
 monsoons	monsoons	monsoons	mónons	monsôns
 ook	ook	ook	ôk	ôk
-kooning	koooning	kooning	koooning	kôoning
 veneers	veneers	veneers	veners	venêrs
 oop	oop	oop	ôp	ôp
 oooo	oooooo	oooo	ooooo	ôôô
@@ -218,7 +212,6 @@ chaffee	chaffee	chaffee	chafee	chaffê
 eeo	eeo	eeo	êo	êo
 ddd	ddd	ddd	dd	đd
 cyclooxygenase	cycloooxygenase	cyclooxygenase	cycloooxygenase	cyclôoxygenase
-kawai	kawwai	kawai	kawwai	kăwai
 haa	haa	haa	hâ	hâ
 ddl	ddl	ddl	đl	đl
 typhoons	typhooons	typhoons	typhooons	typhôons
@@ -226,7 +219,6 @@ mown	mown	mown	mơn	mơn
 uwe	uwe	uwe	ưe	ưe
 veen	veen	veen	vên	vên
 dowson	dowson	dowson	dốn	dơson
-kool	koool	kool	koool	kôol
 boor	boor	boor	bổ	bôr
 eee	eee	eee	ee	êe
 nawaz	nawaz	nawaz	na	năaz
@@ -234,7 +226,6 @@ bylaw	bylaww	bylaw	bylaww	bylăw
 ooooo	ooooooo	ooooo	oooooo	ôôôo
 ooooo	ooooo	ooooo	oooo	ôôo
 noo	noo	noo	nô	nô
-kook	koook	kook	koook	kôok
 goon	goon	goon	gôn	gôn
 aat	aat	aat	ât	ât
 aaas	aaas	aaas	aas	âas
@@ -271,17 +262,13 @@ pensees	pensees	pensees	pénes	pensês
 loons	loons	loons	lốn	lôns
 hows	hows	hows	hớ	hơs
 coops	coops	coops	cốp	côps
-koopmans	kooopmans	koopmans	kooopmans	kôopmans
 refereed	refereed	refereed	rểeed	referêd
 toon	toon	toon	tôn	tôn
 neer	neer	neer	nể	nêr
 tows	tows	tows	tớ	tơs
-koop	kooop	koop	kooop	kôop
 gowan	gowan	gowan	gơan	gơan
-kawamura	kawwamura	kawamura	kawwamura	kăwamura
 longwood	longwood	longwood	longod	longwôd
 ddp	ddp	ddp	đp	đp
-kawakami	kawwakami	kawakami	kawwakami	kăwakami
 aau	aau	aau	âu	âu
 aam	aam	aam	âm	âm
 owi	owi	owi	ơi	ơi
@@ -291,7 +278,6 @@ vdd	vdd	vdd	vđ	vđ
 lowi	lowi	lowi	lơi	lơi
 geen	geeen	geen	geeen	gêen
 nonfood	nonfood	nonfood	nònod	nonfôd
-koopman	kooopman	koopman	kooopman	kôopman
 goof	gooof	goof	goò	gôof
 goof	goof	goof	gồ	gôf
 beekeepers	beeekeeepers	beekeepers	beekeeepers	bêekêepers
@@ -299,12 +285,11 @@ meow	meow	meow	meơ	meơ
 beeps	beeps	beeps	bếp	bêps
 boons	boons	boons	bốn	bôns
 macaw	macaw	macaw	măc	macă
-koontz	kooontz	koontz	kooontz	kôontz
 oom	oom	oom	ôm	ôm
 aai	aaai	aai	aaai	âai
 aai	aai	aai	âi	âi
 goodlooking	gooodloooking	goodlooking	goodloooking	gôodlôoking
-kow	koww	kow	koww	kơw
+kow	kow	kow	kơ	kơ
 oor	oor	oor	ổ	ôr
 geeta	geeeta	geeta	geeeta	gêeta
 teem	teem	teem	têm	têm
@@ -327,27 +312,21 @@ oost	ooost	oost	oót	ôost
 oost	oost	oost	ốt	ôst
 deedee	deeedeee	deedee	deedeee	dêedêe
 deedee	deedee	deedee	đêee	dêdê
-kawaguchi	kawwaguchi	kawaguchi	kawwaguchi	kăwaguchi
 aav	aav	aav	âv	âv
 mdd	mdd	mdd	mđ	mđ
 beekeeper	beeekeeeper	beekeeper	beekeeeper	bêekêeper
 geez	geeez	geez	geeez	gêez
 towson	towson	towson	tốn	tơson
 aag	aag	aag	âg	âg
-kawabata	kawwabata	kawabata	kawwabata	kăwabata
 hoon	hoon	hoon	hôn	hôn
 ddi	ddi	ddi	đi	đi
 booz	booz	booz	bo	bôz
 raa	raa	raa	râ	râ
 awn	awn	awn	ăn	ăn
-kootenay	koootenay	kootenay	koootenay	kôotenay
 maass	maass	maass	mas	mâss
 oaa	oaa	oaa	oâ	oâ
-kaw	kaww	kaw	kaww	kăw
 doodling	dooodling	doodling	dooling	dôodling
 thaws	thaws	thaws	thắ	thăs
-kawashima	kawwashima	kawashima	kawwashima	kăwashima
-kuwaitis	kuwwaitis	kuwaitis	kuwwaitis	kưwaitis
 geeks	geeeks	geeks	geeeks	gêeks
 mees	mees	mees	mế	mês
 beseeched	beseeched	beseeched	beéched	besêched
@@ -358,7 +337,6 @@ tyree	tyreee	tyree	tyẻe	tyrêe
 owa	owa	owa	ơa	ơa
 tepees	tepees	tepees	tepes	tepês
 gawk	gawk	gawk	găk	găk
-kaaba	kaaaba	kaaba	kaaaba	kâaba
 ool	ool	ool	ôl	ôl
 oroonoko	oroonoko	oroonoko	oỏnoko	orônoko
 hoodoo	hooodooo	hoodoo	hoodooo	hôodôo
@@ -371,7 +349,6 @@ khoo	khoo	khoo	khô	khô
 eek	eek	eek	êk	êk
 howson	howson	howson	hốn	hơson
 bowra	bowra	bowra	bởa	bơra
-koon	kooon	koon	kooon	kôon
 eed	eed	eed	êd	êd
 oooooooo	oooooooooooo	oooooooo	ooooooooooo	ôôôôôô
 oooooooo	oooooooo	oooooooo	ooooooo	ôôôô
@@ -383,8 +360,7 @@ macaws	macaws	macaws	mắc	macăs
 wallflower	wallflower	wallflower	ửàlllowe	wallflơer
 powis	powis	powis	pới	pơis
 lydda	lyddda	lydda	lyddda	lyđda
-kaa	kaaa	kaa	kaaa	kâa
-koos	kooos	koos	kooos	kôos
+kaa	kaa	kaa	kâ	kâ
 aways	aways	aways	ấy	ăays
 lowbrow	lowwbroww	lowbrow	lowbroww	lơwbrơw
 coots	coots	coots	cốt	côts

--- a/core/tests/data/english_100k_failures_tone.txt
+++ b/core/tests/data/english_100k_failures_tone.txt
@@ -1,7 +1,7 @@
 # English 100k Failures - Tone Markers
 # Cause: words ending with s/f/r/x/j trigger tone marks
 # Format: WORD \t ACTUAL \t BUFFER
-# Total: 1251 (+ 95 both)
+# Total: 1267 (+ 95 both)
 #
 # WORD: English word typed
 # ACTUAL: engine output after space
@@ -541,6 +541,7 @@ trojans	troán	troán
 lias	lía	lía
 tur	tủ	tủ
 ner	nẻ	nẻ
+kar	kả	kả
 bores	boé	boé
 afr	ả	ả
 borer	boer	boer
@@ -718,6 +719,7 @@ parris	paris	paris
 isms	ims	ims
 cosas	coas	coas
 dorr	dor	dor
+kor	kỏ	kỏ
 heures	hếu	hếu
 thongs	thóng	thóng
 nomos	nốm	nốm
@@ -739,11 +741,13 @@ tures	tué	tué
 armas	ấm	ấm
 neusner	nểun	nểun
 dorms	dóm	dóm
+kans	kán	kán
 vex	vẽ	vẽ
 raff	raf	raf
 tir	tỉ	tỉ
 urs	ú	ú
 ters	té	té
+kaur	kảu	kảu
 soir	sỏi	sỏi
 lacs	lác	lác
 asf	à	à
@@ -771,6 +775,7 @@ gongs	góng	góng
 tans	tán	tán
 haj	hạ	hạ
 mips	míp	míp
+kass	kas	kas
 gos	gó	gó
 manx	mãn	mãn
 hurons	huón	huón
@@ -779,6 +784,7 @@ yf	ỳ	ỳ
 cus	cú	cú
 sof	sò	sò
 ror	rỏ	rỏ
+kos	kó	kó
 darauf	dầu	dầu
 memes	mếm	mếm
 hass	has	has
@@ -909,6 +915,7 @@ syr	sỷ	sỷ
 ressources	resources	resources
 doss	dos	dos
 anf	àn	àn
+karr	kar	kar
 asuras	ấu	ấu
 lajos	láo	láo
 quips	quíp	quíp
@@ -928,10 +935,12 @@ suf	sù	sù
 swf	sừ	sừ
 nif	nì	nì
 pemex	pễm	pễm
+koss	kos	kos
 neces	nếc	nếc
 gor	gỏ	gỏ
 buts	bút	bút
 vars	vá	vá
+kas	ká	ká
 kir	kỉ	kỉ
 kis	kí	kí
 pwr	pử	pử
@@ -942,6 +951,7 @@ oes	oé	oé
 auras	ấu	ấu
 dus	dú	dú
 trots	trót	trót
+karmas	kấm	kấm
 tots	tót	tót
 ursus	úu	úu
 kronos	krốn	krốn
@@ -989,6 +999,7 @@ hirer	hier	hier
 sops	sóp	sóp
 amax	ẫm	ẫm
 gyms	gým	gým
+kafir	kải	kải
 dess	des	des
 ruses	rues	rues
 gaf	gà	gà
@@ -1052,11 +1063,13 @@ amj	ạm	ạm
 usps	ups	ups
 chur	chủ	chủ
 bots	bót	bót
+kars	ká	ká
 larus	láu	láu
 posix	põi	põi
 nias	nía	nía
 meses	mes	mes
 puer	puẻ	puẻ
+kur	kủ	kủ
 eor	ẻo	ẻo
 duos	duó	duó
 tux	tũ	tũ
@@ -1153,6 +1166,7 @@ ress	res	res
 riss	ris	ris
 nars	ná	ná
 conj	cọn	cọn
+kaj	kạ	kạ
 sofer	soẻ	soẻ
 suraj	sụa	sụa
 ganj	gạn	gạn
@@ -1188,6 +1202,7 @@ tuns	tún	tún
 bienes	biến	biến
 mef	mè	mè
 doerr	doer	doer
+kafirs	kái	kái
 laf	là	là
 guis	gúi	gúi
 sechs	séch	séch
@@ -1206,10 +1221,10 @@ oer	oẻ	oẻ
 enfer	ển	ển
 dox	dõ	dõ
 kier	kiẻ	kiẻ
-kamaraj	kkamaraj	kamaraj
 unf	ùn	ùn
 demers	dếm	dếm
 maur	mảu	mảu
+kanwar	kẩn	kẩn
 rauf	ràu	ràu
 mys	mý	mý
 coms	cóm	cóm
@@ -1228,6 +1243,7 @@ teos	téo	téo
 locos	lốc	lốc
 ays	áy	áy
 isf	ì	ì
+kangas	kấng	kấng
 bwr	bử	bử
 laus	láu	láu
 basor	bảo	bảo

--- a/core/tests/data/english_100k_failures_vowel.txt
+++ b/core/tests/data/english_100k_failures_vowel.txt
@@ -1,7 +1,7 @@
 # English 100k Failures - Vowel Patterns
 # Cause: aa/ee/oo/aw/ow/uw/dd trigger vowel transforms
 # Format: WORD \t ACTUAL \t BUFFER
-# Total: 219 (+ 95 both)
+# Total: 222 (+ 95 both)
 #
 # WORD: English word typed
 # ACTUAL: engine output after space
@@ -107,6 +107,7 @@ baa	bâ	bâ
 saa	sâ	sâ
 dowd	đơ	đơ
 roo	rô	rô
+koo	kô	kô
 aad	âd	âd
 dde	đe	đe
 swoon	suôn	suôn
@@ -178,6 +179,7 @@ meow	meơ	meơ
 macaw	măc	măc
 oom	ôm	ôm
 aai	âi	âi
+kow	kơ	kơ
 teem	têm	têm
 daa	dâ	dâ
 pdd	pđ	pđ
@@ -221,6 +223,7 @@ eed	êd	êd
 oooooooo	ooooooo	ooooooo
 daan	dân	dân
 fdd	fđ	fđ
+kaa	kâ	kâ
 lown	lơn	lơn
 eep	êp	êp
 oooooo	ooooo	ooooo

--- a/core/tests/foreign_consonants_test.rs
+++ b/core/tests/foreign_consonants_test.rs
@@ -105,6 +105,20 @@ fn foreign_with_full_syllables() {
 // ============================================================
 
 #[test]
+fn k_before_back_vowels_always_allowed() {
+    // k before a/o/u is accepted regardless of the option (Bắc Kạn, Hồng Kông)
+    let cases = &[
+        ("koong", "kông"),
+        ("kanj", "kạn"),
+        ("kawng", "kăng"),
+        ("kuwng", "kưng"),
+        ("kaf", "kà"),
+    ];
+    telex_foreign(cases);
+    telex_no_foreign(cases);
+}
+
+#[test]
 fn no_foreign_z_passthrough() {
     // When disabled, z should not get diacritics (invalid initial)
     telex_no_foreign(&[

--- a/core/tests/integration_test.rs
+++ b/core/tests/integration_test.rs
@@ -243,12 +243,13 @@ fn telex_w_as_vowel_after_valid_consonant() {
 }
 
 #[test]
-fn telex_w_passthrough_after_invalid_consonant() {
-    // "kw" → "kw" (invalid: k cannot precede ư)
+fn telex_w_after_k_becomes_u_horn() {
+    // "kw" → "kư" (k before a/o/u allowed for proper nouns like Bắc Kạn)
     let mut e = Engine::new();
     e.on_key(keys::K, false, false);
     let result = e.on_key(keys::W, false, false);
-    assert_eq!(result.action, 0); // passthrough
+    assert_eq!(result.action, 1);
+    assert_eq!(result.chars[0], 'ư' as u32);
 }
 
 #[test]

--- a/core/tests/typing_test.rs
+++ b/core/tests/typing_test.rs
@@ -1250,8 +1250,7 @@ const TELEX_INVALID_BREVE_OPEN: &[(&str, &str)] = &[
     ("phaw", "phă"),
     ("traw", "tră"),
     ("ngaw", "ngă"),
-    // Invalid Vietnamese spelling - breve blocked by validation
-    ("kaw", "kaw"), // k before a is invalid
+    ("kaw", "kă"), // k before a allowed for proper nouns (Bắc Kạn)
     // Standalone aw
     ("aw", "ă"),
 ];


### PR DESCRIPTION
## Description

Syllables starting with `k` + a/o/u (`kông`, `kạn`, `kăng`, `kưng`) could not receive diacritics, blocking proper nouns like **Hồng Kông** and **Bắc Kạn**. `k` is now accepted before a/o/u, independent of the "Cho phép phụ âm ngoại" option.

## Type of Change

- [x] Bug fix

## Root Cause

The spelling rule `"k before a/o/u"` in `SPELLING_RULES` marked these syllables as invalid, so tone/mark application was skipped. The foreign-consonants option only relaxed the initial-consonant check for z/w/j/f and never touched this rule.

## Fix

Removed the `k before a/o/u` spelling rule. Standard Vietnamese uses `c` there, but real proper nouns and loanwords need `k`, and there is no ambiguity for the engine. Rules for `c`/`g`/`ng`/`gh`/`ngh` are unchanged. Made it always-on so users don't need to find a setting.

## Testing

1. Telex: `Hoongf Koong` → `Hồng Kông`; `Bawcs Kanj` → `Bắc Kạn`.
2. VNI: `ko6ng` → `kông`; `ka5n` → `kạn`.
3. Regression: `ci`, `ce`, `ge` still not tone-marked; `nghe` still valid.
4. `cargo test` → 988 passed, 0 failed.

## Trade-off

English passthrough: 24 fewer failures overall (`kuwait`, `kawasaki`, `kowloon` now restore correctly), but a few rare short words (`kos`, `kas`, `koo`, `kow`) get marks if typed without space-restore.

## Checklist

- [x] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated

Fixes #393
