### PR TITLE
feat(macos): show which app holds Secure Input

### DIFF
--- a/platforms/macos/MainSettingsView.swift
+++ b/platforms/macos/MainSettingsView.swift
@@ -77,6 +77,8 @@ class AppState: ObservableObject {
     }
 
     @Published private(set) var isSecureInputBlocked = false
+    /// App reported by macOS as holding Secure Input; nil when unknown or not blocked.
+    @Published private(set) var secureInputHolderName: String?
 
     var shouldShowSecureInputWarning: Bool {
         SecureInputPresentation.shouldShow(
@@ -86,11 +88,12 @@ class AppState: ObservableObject {
         )
     }
 
-    func setSecureInputBlocked(_ blocked: Bool) {
+    func setSecureInputBlocked(_ blocked: Bool, holderName: String? = nil) {
         guard Thread.isMainThread else {
-            DispatchQueue.main.async { [weak self] in self?.setSecureInputBlocked(blocked) }
+            DispatchQueue.main.async { [weak self] in self?.setSecureInputBlocked(blocked, holderName: holderName) }
             return
         }
+        secureInputHolderName = blocked ? holderName : nil
         guard isSecureInputBlocked != blocked else { return }
         isSecureInputBlocked = blocked
     }
@@ -989,7 +992,7 @@ struct SettingsPageView: View {
                     VStack(alignment: .leading, spacing: 3) {
                         Text("Bộ gõ đang tạm dừng")
                             .font(.system(size: 13, weight: .semibold))
-                        Text("macOS Secure Input đang chặn bộ gõ. Rời ô mật khẩu hoặc ứng dụng đang giữ Secure Input; Gõ Nhanh sẽ tự hoạt động lại.")
+                        Text(SecureInputPresentation.warningMessage(holderName: appState.secureInputHolderName))
                             .font(.system(size: 11))
                             .foregroundColor(.secondary)
                     }

--- a/platforms/macos/MenuBar.swift
+++ b/platforms/macos/MenuBar.swift
@@ -147,6 +147,9 @@ class MenuBarController: NSObject, NSWindowDelegate {
 
     private var statusSubtitle: String {
         if appState.shouldShowSecureInputWarning {
+            if let holder = appState.secureInputHolderName {
+                return "Tạm dừng · Secure Input (\(holder))"
+            }
             return "Tạm dừng · Secure Input"
         }
         let mode = appState.isEnabled ? appState.currentMethod.name : "Đã tắt"
@@ -205,6 +208,7 @@ class MenuBarController: NSObject, NSWindowDelegate {
            let subtitle = headerView.viewWithTag(100) as? NSTextField
         {
             subtitle.stringValue = statusSubtitle
+            headerView.frame.size.width = headerView.fittingSize.width
         }
 
         menu.item(withTag: 10)?.state = appState.currentMethod == .telex ? .on : .off
@@ -299,7 +303,7 @@ class MenuBarController: NSObject, NSWindowDelegate {
                 button.image = createStatusIcon(text: text)
             }
             button.toolTip = isSecureInputBlocked
-                ? "Gõ Nhanh đang tạm dừng vì macOS Secure Input"
+                ? SecureInputPresentation.tooltip(holderName: appState.secureInputHolderName)
                 : nil
         }
     }

--- a/platforms/macos/RustBridge.swift
+++ b/platforms/macos/RustBridge.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Carbon
 import Foundation
+import IOKit
 
 // MARK: - Accessibility helpers
 
@@ -838,6 +839,64 @@ enum SecureInputPresentation {
     static func shouldShow(engineEnabled: Bool, inputSourceAllowed: Bool, secureInputBlocked: Bool) -> Bool {
         engineEnabled && inputSourceAllowed && secureInputBlocked
     }
+
+    /// Sentence shown while blocked. Names the holder when macOS reports one so the
+    /// user knows which app to leave or quit; falls back to generic guidance otherwise.
+    static func warningMessage(holderName: String?) -> String {
+        if let name = holderName {
+            return "\(name) đang giữ macOS Secure Input. Rời ô mật khẩu hoặc thoát ứng dụng đó; Gõ Nhanh sẽ tự hoạt động lại."
+        }
+        return "macOS Secure Input đang chặn bộ gõ. Rời ô mật khẩu hoặc ứng dụng đang giữ Secure Input; Gõ Nhanh sẽ tự hoạt động lại."
+    }
+
+    static func tooltip(holderName: String?) -> String {
+        if let name = holderName {
+            return "Gõ Nhanh đang tạm dừng vì \(name) giữ macOS Secure Input"
+        }
+        return "Gõ Nhanh đang tạm dừng vì macOS Secure Input"
+    }
+}
+
+/// Identifies which process holds macOS Secure Input.
+///
+/// WindowServer publishes the holder as `kCGSSessionSecureInputPID` inside the
+/// `IOConsoleUsers` property of the IORegistry root (the same value `ioreg` shows).
+/// macOS attributes the PID to the *responsible* process, so a browser launched from a
+/// terminal (e.g. Playwright E2E) is reported as the terminal or IDE that spawned it.
+enum SecureInputHolder {
+    static let sessionPIDKey = "kCGSSessionSecureInputPID"
+
+    static func holderPID(consoleUsers: [[String: Any]]) -> pid_t? {
+        for session in consoleUsers {
+            if let pid = session[sessionPIDKey] as? Int, pid > 0 {
+                return pid_t(pid)
+            }
+        }
+        return nil
+    }
+
+    static func currentPID() -> pid_t? {
+        let root = IORegistryGetRootEntry(kIOMainPortDefault)
+        defer { IOObjectRelease(root) }
+        guard let users = IORegistryEntryCreateCFProperty(root, "IOConsoleUsers" as CFString, kCFAllocatorDefault, 0)?
+            .takeRetainedValue() as? [[String: Any]]
+        else { return nil }
+        return holderPID(consoleUsers: users)
+    }
+
+    /// Human-readable app name for the current holder, or nil when macOS reports none.
+    static func currentName() -> String? {
+        guard let pid = currentPID() else { return nil }
+        if let app = NSRunningApplication(processIdentifier: pid), let name = app.localizedName {
+            return name
+        }
+        // Not an NSRunningApplication (daemon, CLI): fall back to the executable name.
+        // PROC_PIDPATHINFO_MAXSIZE (4 * MAXPATHLEN) is a C macro not visible to Swift.
+        var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN) * 4)
+        guard proc_pidpath(pid, &buffer, UInt32(buffer.count)) > 0 else { return nil }
+        let path = String(cString: buffer)
+        return (path as NSString).lastPathComponent
+    }
 }
 
 enum SecureInputRefreshPolicy {
@@ -979,8 +1038,9 @@ class KeyboardHookManager {
             return
         case .becameBlocked:
             RustBridge.clearBufferAll()
-            AppState.shared.setSecureInputBlocked(true)
-            Log.info("secure input: blocked")
+            let holder = SecureInputHolder.currentName()
+            AppState.shared.setSecureInputBlocked(true, holderName: holder)
+            Log.info("secure input: blocked by \(holder ?? "unknown process")")
         case .becameAvailable:
             RustBridge.clearBufferAll()
             if let tap = eventTap {

--- a/platforms/macos/Tests/KeyboardShortcutTests.swift
+++ b/platforms/macos/Tests/KeyboardShortcutTests.swift
@@ -470,4 +470,24 @@ final class SecureInputRecoveryTests: XCTestCase {
             engineEnabled: true, inputSourceAllowed: true, secureInputBlocked: false
         ))
     }
+
+    func testHolderPIDReadsFirstPositiveSessionPID() {
+        XCTAssertNil(SecureInputHolder.holderPID(consoleUsers: []))
+        XCTAssertNil(SecureInputHolder.holderPID(consoleUsers: [["kCGSSessionUserNameKey": "a"]]))
+        XCTAssertNil(SecureInputHolder.holderPID(consoleUsers: [[SecureInputHolder.sessionPIDKey: 0]]))
+        XCTAssertEqual(
+            SecureInputHolder.holderPID(consoleUsers: [
+                ["kCGSSessionUserNameKey": "a"],
+                [SecureInputHolder.sessionPIDKey: 2463],
+            ]),
+            2463
+        )
+    }
+
+    func testWarningTextNamesHolderWhenKnown() {
+        XCTAssertTrue(SecureInputPresentation.warningMessage(holderName: "Chromium").hasPrefix("Chromium đang giữ"))
+        XCTAssertTrue(SecureInputPresentation.warningMessage(holderName: nil).hasPrefix("macOS Secure Input"))
+        XCTAssertTrue(SecureInputPresentation.tooltip(holderName: "Chromium").contains("Chromium"))
+        XCTAssertFalse(SecureInputPresentation.tooltip(holderName: nil).contains("("))
+    }
 }


### PR DESCRIPTION
## Description

When macOS Secure Input blocks the input method, show which app is holding it in the menu bar subtitle, tooltip, and settings warning so users know what to leave or quit.

## Type of Change

- [x] New feature

## Root Cause

Secure Input is OS-level: once any process enables it, macOS stops delivering keyboard events to every event tap and input methods cannot bypass it. Chromium/WebKit enable it whenever a password field is focused — including headless browsers driven by Playwright — so E2E login tests block typing in bursts (#417). The app already recovers automatically (#414) but only showed a generic warning, so users couldn't tell which app was responsible (#412).

## Fix

Read the holder PID (`kCGSSessionSecureInputPID` in the IORegistry `IOConsoleUsers` property — same value `ioreg` shows) when Secure Input becomes active, resolve it to an app name, and surface it in the UI. Generic text is kept when macOS reports no holder. Note: macOS reports the *responsible* process, so a browser launched from a terminal/IDE shows that terminal/IDE.

## Testing

1. Enable Gõ Nhanh, then focus a `sudo` password prompt in Terminal.
2. Menu bar shows `Tạm dừng · Secure Input (Terminal)`; tooltip and settings banner name the app; log shows `secure input: blocked by Terminal`.
3. Cancel the prompt — warning clears, Vietnamese typing resumes.
4. `xcodebuild … test` passes, including two new `SecureInputRecoveryTests`.

## Checklist

- [x] Tests pass
- [ ] Documentation updated
- [ ] CHANGELOG.md updated
